### PR TITLE
Bump version and update Sonar properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     </parent>
 
     <artifactId>software-cryptography-provider</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2-SNAPSHOT</version>
     <name>CZERTAINLY-Software-Cryptography-Provider</name>
 
     <properties>
         <java.version>21</java.version>
-        <sonar.organization>czertainly</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.projectKey>CZERTAINLY_CZERTAINLY-Software-Cryptography-Provider</sonar.projectKey>
+        <sonar.organization>ilm</sonar.organization>
+        <sonar.projectKey>ilm_software-cryptography-provider</sonar.projectKey>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
- update project version to 1.3.2-SNAPSHOT for ongoing development
- adjust SonarCloud configuration: set sonar.organization to 'ilm' and sonar.projectKey to 'ilm_software-cryptography-provider' to reflect the new organization/project mapping.