### PR TITLE
Correctness fixes, migrate ML-KEM storage format and new integration tests

### DIFF
--- a/scripts/perf/connector-sign-once.sh
+++ b/scripts/perf/connector-sign-once.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# connector-sign-once.sh
+#
+# Test script which:
+#   1. Discover token creation attribute definitions from the connector
+#   2. Create a token
+#   3. Discover key-pair creation attribute definitions from the connector
+#   4. Create an RSA key pair inside that token
+#   5. Perform one sign operation
+#   6. Destroy the key pair (private + public keys)
+#   7. Destroy the token
+#
+# Attribute UUIDs are fetched live from the connector before each operation so
+# the script does not need to hard-code UUIDs that may change between releases.
+# (Sign operation attributes have no connector-side attribute endpoint — they
+#  are controlled by Core — and are therefore sent by name as documented in the
+#  connector source.)
+#
+# Requires: curl, jq
+#
+# Usage:
+#   ./connector-sign-once.sh
+#
+# Environment variables (all optional):
+#   BASE_URL      Connector base URL                             (default: http://localhost:8230)
+#   TOKEN_NAME    Name for the ephemeral token instance          (default: k6PerfToken)
+#   TOKEN_PASS    Token password / code                          (default: k6-test-token-secret)
+#   KEY_ALIAS     Alias for the ephemeral key pair               (default: k6RsaKey)
+#   KEY_SIZE      RSA key size in bits: 1024 | 2048 | 4096       (default: 2048)
+#   SIG_SCHEME    RSA signature scheme: PSS | PKCS1-v1_5         (default: PSS)
+#   DIGEST        Digest algorithm: SHA-256 | SHA-384 | SHA-512  (default: SHA-384)
+#   DATA_B64      Base64-encoded data to sign                    (default: "connector-sign-k6-test")
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8230}"
+TOKEN_NAME="${TOKEN_NAME:-k6PerfToken}"
+TOKEN_PASS="${TOKEN_PASS:-k6-test-token-secret}"
+KEY_ALIAS="${KEY_ALIAS:-k6RsaKey}"
+KEY_SIZE="${KEY_SIZE:-2048}"
+SIG_SCHEME="${SIG_SCHEME:-PSS}"
+DIGEST="${DIGEST:-SHA-384}"
+# base64("connector-sign-k6-test")
+DATA_B64="${DATA_B64:-Y29ubmVjdG9yLXNpZ24tazYtdGVzdA==}"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+# connector_curl METHOD RELATIVE_PATH [BODY_JSON]
+# Makes a call to the connector; dies on non-2xx status.
+connector_curl() {
+    local method="$1" path="$2" body="${3:-}"
+    local tmp http_code response
+    tmp=$(mktemp)
+    if [[ -n "$body" ]]; then
+        http_code=$(curl -s -o "$tmp" -w "%{http_code}" \
+            -X "$method" \
+            -H 'Content-Type: application/json' -H 'Accept: application/json' \
+            -d "$body" \
+            "${BASE_URL}${path}")
+    else
+        http_code=$(curl -s -o "$tmp" -w "%{http_code}" \
+            -X "$method" \
+            -H 'Content-Type: application/json' -H 'Accept: application/json' \
+            "${BASE_URL}${path}")
+    fi
+    response=$(<"$tmp"); rm -f "$tmp"
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        die "HTTP ${http_code} on ${method} ${path}: ${response}"
+    fi
+    echo "$response"
+}
+
+# attr_uuid ATTRS_JSON NAME CONTENT_TYPE
+# Looks up the uuid of a data attribute by name + contentType.
+# Exits with a diagnostic if not found.
+attr_uuid() {
+    local attrs="$1" name="$2" content_type="$3"
+    local uuid
+    uuid=$(echo "$attrs" | jq -r \
+        --arg n "$name" --arg ct "$content_type" \
+        'first(.[] | select(.name==$n and .contentType==$ct) | .uuid) // empty')
+    if [[ -z "$uuid" ]]; then
+        echo "ERROR: Attribute  name='${name}'  contentType='${content_type}'  not found." >&2
+        echo "       Received attributes:" >&2
+        echo "$attrs" | jq -r \
+            '.[] | "         name=\(.name)  contentType=\(.contentType // "(none)")  type=\(.type)"' >&2
+        exit 1
+    fi
+    echo "$uuid"
+}
+
+# group_uuid ATTRS_JSON NAME
+# Looks up the uuid of a group attribute by name.
+group_uuid() {
+    local attrs="$1" name="$2"
+    local uuid
+    uuid=$(echo "$attrs" | jq -r \
+        --arg n "$name" \
+        'first(.[] | select(.name==$n and .type=="group") | .uuid) // empty')
+    if [[ -z "$uuid" ]]; then
+        echo "ERROR: Group attribute  name='${name}'  not found." >&2
+        echo "       Received attributes:" >&2
+        echo "$attrs" | jq -r \
+            '.[] | "         name=\(.name)  contentType=\(.contentType // "(none)")  type=\(.type)"' >&2
+        exit 1
+    fi
+    echo "$uuid"
+}
+
+# ─── Cleanup (runs on EXIT) ───────────────────────────────────────────────────
+
+TOKEN_UUID=''
+TOKEN_PREEXISTED=false
+PRIVATE_KEY_UUID=''
+PUBLIC_KEY_UUID=''
+
+# connector_curl_soft METHOD RELATIVE_PATH [BODY_JSON]
+# Like connector_curl but warns on non-2xx instead of exiting.
+# Used inside cleanup() so that a failed step does not abort subsequent ones
+# (connector_curl calls die() -> exit 1, which would terminate the shell even
+# from within a trap handler, making || echo "WARNING" ineffective).
+connector_curl_soft() {
+    local method="$1" path="$2" body="${3:-}"
+    local tmp http_code response
+    tmp=$(mktemp)
+    if [[ -n "$body" ]]; then
+        http_code=$(curl -s -o "$tmp" -w "%{http_code}" \
+            -X "$method" \
+            -H 'Content-Type: application/json' -H 'Accept: application/json' \
+            -d "$body" \
+            "${BASE_URL}${path}") || true
+    else
+        http_code=$(curl -s -o "$tmp" -w "%{http_code}" \
+            -X "$method" \
+            -H 'Content-Type: application/json' -H 'Accept: application/json' \
+            "${BASE_URL}${path}") || true
+    fi
+    response=$(<"$tmp"); rm -f "$tmp"
+    if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+        echo "  WARNING: HTTP ${http_code} on ${method} ${path}: ${response}" >&2
+        return 1
+    fi
+    echo "$response"
+}
+
+cleanup() {
+    echo ""
+    echo "=== Cleanup ==="
+    if [[ -n "$PRIVATE_KEY_UUID" ]]; then
+        echo "  Deleting private key $PRIVATE_KEY_UUID ..."
+        if connector_curl_soft DELETE \
+                "/v1/cryptographyProvider/tokens/${TOKEN_UUID}/keys/${PRIVATE_KEY_UUID}"; then
+            echo "    Private key deleted."
+        else
+            echo "    WARNING: failed to delete private key."
+        fi
+    fi
+    if [[ -n "$PUBLIC_KEY_UUID" ]]; then
+        echo "  Deleting public key $PUBLIC_KEY_UUID ..."
+        if connector_curl_soft DELETE \
+                "/v1/cryptographyProvider/tokens/${TOKEN_UUID}/keys/${PUBLIC_KEY_UUID}"; then
+            echo "    Public key deleted."
+        else
+            echo "    WARNING: failed to delete public key."
+        fi
+    fi
+    if [[ -n "$TOKEN_UUID" && "$TOKEN_PREEXISTED" == "false" ]]; then
+        echo "  Deleting token $TOKEN_UUID ..."
+        if connector_curl_soft DELETE \
+                "/v1/cryptographyProvider/tokens/${TOKEN_UUID}"; then
+            echo "    Token deleted."
+        else
+            echo "    WARNING: failed to delete token."
+        fi
+    fi
+}
+
+trap cleanup EXIT
+
+# ─── Step 1: Discover token creation attributes ────────────────────────────────
+#
+# GET /v1/cryptographyProvider/SOFT/attributes returns different attribute sets
+# depending on whether tokens already exist:
+#   - No existing tokens → attributes for new-token creation are returned directly.
+#   - Existing tokens    → a data_options selector + a group_loadToken group (with
+#                          a callback) are returned; a separate callback call
+#                          resolves the new-token sub-attributes.
+
+echo "=== Step 1: Discover token creation attributes ==="
+TOKEN_TOP_ATTRS=$(connector_curl GET "/v1/cryptographyProvider/SOFT/attributes")
+
+OPTIONS_UUID=''
+if echo "$TOKEN_TOP_ATTRS" | jq -e '[.[].name] | any(. == "data_options")' > /dev/null 2>&1; then
+    echo "  Existing tokens found — fetching 'Create new Token' sub-attributes via callback."
+    OPTIONS_UUID=$(attr_uuid "$TOKEN_TOP_ATTRS" "data_options" "string")
+    TOKEN_NEW_ATTRS=$(connector_curl GET "/v1/cryptographyProvider/callbacks/token/new/attributes")
+else
+    echo "  No existing tokens — new-token attributes returned directly."
+    TOKEN_NEW_ATTRS="$TOKEN_TOP_ATTRS"
+fi
+
+ACTION_UUID=$(attr_uuid "$TOKEN_NEW_ATTRS" "data_createTokenAction" "string")
+NAME_UUID=$(attr_uuid   "$TOKEN_NEW_ATTRS" "data_newTokenName"      "string")
+CODE_UUID=$(attr_uuid   "$TOKEN_NEW_ATTRS" "data_tokenCode"         "secret")
+echo "  data_createTokenAction uuid : $ACTION_UUID"
+echo "  data_newTokenName      uuid : $NAME_UUID"
+echo "  data_tokenCode         uuid : $CODE_UUID"
+[[ -n "$OPTIONS_UUID" ]] && echo "  data_options           uuid : $OPTIONS_UUID"
+
+# ─── Step 2: Create token or reuse existing ───────────────────────────────────
+
+echo ""
+echo "=== Step 2: Create token '$TOKEN_NAME' ==="
+
+# Check whether a token with this name already exists; reuse it if so.
+EXISTING_TOKENS=$(connector_curl_soft GET "/v1/cryptographyProvider/tokens") || true
+TOKEN_UUID=$(echo "$EXISTING_TOKENS" | jq -r \
+    --arg name "$TOKEN_NAME" \
+    'if type == "array" then (first(.[] | select(.name == $name) | .uuid) // empty) else empty end' \
+    2>/dev/null || true)
+
+if [[ -n "$TOKEN_UUID" ]]; then
+    TOKEN_PREEXISTED=true
+    echo "  Token already exists — reusing UUID: $TOKEN_UUID"
+else
+    # Build the options attribute entry conditionally (only present when the server
+    # returned data_options, i.e. when tokens already exist).
+    OPTIONS_ATTR_JSON='[]'
+    if [[ -n "$OPTIONS_UUID" ]]; then
+        OPTIONS_ATTR_JSON=$(jq -n \
+            --arg uuid "$OPTIONS_UUID" \
+            '[{uuid: $uuid, name: "data_options", contentType: "string", version: "v2",
+               content: [{reference: "new", data: "Create new Token"}]}]')
+    fi
+
+    CREATE_TOKEN_BODY=$(jq -n \
+        --arg  name       "$TOKEN_NAME" \
+        --arg  actionUuid "$ACTION_UUID" \
+        --arg  nameUuid   "$NAME_UUID" \
+        --arg  codeUuid   "$CODE_UUID" \
+        --arg  tokenPass  "$TOKEN_PASS" \
+        --argjson optAttrs "$OPTIONS_ATTR_JSON" \
+        '$optAttrs + [
+            {uuid: $actionUuid, name: "data_createTokenAction", contentType: "string",
+             version: "v2", content: [{reference: "new", data: "new"}]},
+            {uuid: $nameUuid, name: "data_newTokenName", contentType: "string",
+             version: "v2", content: [{data: $name}]},
+            {uuid: $codeUuid, name: "data_tokenCode", contentType: "secret",
+             version: "v2", content: [{reference: $name, data: {secret: $tokenPass}}]}
+        ] | {name: $name, kind: "SOFT", attributes: .}')
+
+    CREATE_TOKEN_RESP=$(connector_curl POST "/v1/cryptographyProvider/tokens" "$CREATE_TOKEN_BODY") \
+        || die "Token creation failed."
+
+    TOKEN_UUID=$(echo "$CREATE_TOKEN_RESP" | jq -r '.uuid // empty')
+    [[ -n "$TOKEN_UUID" ]] \
+        || die "Token UUID missing from response: $CREATE_TOKEN_RESP"
+    echo "  Token UUID: $TOKEN_UUID"
+fi
+
+# ─── Step 3: Discover key-pair creation attributes ────────────────────────────
+#
+# GET /v1/cryptographyProvider/tokens/{tokenUuid}/keys/pair/attributes returns:
+#   data_keyAlias (string), data_keyAlgorithm (string), group_keySpec (group).
+# The group_keySpec carries a callback to resolve algorithm-specific attributes.
+# For RSA: GET /v1/cryptographyProvider/callbacks/keyspec/RSA/attributes
+#   returns data_rsaKeySize (integer).
+
+echo ""
+echo "=== Step 3: Discover key-pair creation attributes ==="
+KEYPAIR_ATTR_DEFS=$(connector_curl GET \
+    "/v1/cryptographyProvider/tokens/${TOKEN_UUID}/keys/pair/attributes")
+
+ALIAS_UUID=$(attr_uuid   "$KEYPAIR_ATTR_DEFS" "data_keyAlias"     "string")
+ALG_UUID=$(attr_uuid     "$KEYPAIR_ATTR_DEFS" "data_keyAlgorithm" "string")
+echo "  data_keyAlias     uuid : $ALIAS_UUID"
+echo "  data_keyAlgorithm uuid : $ALG_UUID"
+
+RSA_SPEC_ATTRS=$(connector_curl GET \
+    "/v1/cryptographyProvider/callbacks/keyspec/RSA/attributes")
+RSA_SIZE_UUID=$(attr_uuid "$RSA_SPEC_ATTRS" "data_rsaKeySize" "integer")
+echo "  data_rsaKeySize   uuid : $RSA_SIZE_UUID"
+
+# ─── Step 4: Create RSA key pair ──────────────────────────────────────────────
+
+echo ""
+echo "=== Step 4: Create RSA-${KEY_SIZE} key pair (alias: ${KEY_ALIAS}) ==="
+
+CREATE_KEY_BODY=$(jq -n \
+    --arg  aliasUuid   "$ALIAS_UUID" \
+    --arg  algUuid     "$ALG_UUID" \
+    --arg  sizeUuid    "$RSA_SIZE_UUID" \
+    --arg  keyAlias    "$KEY_ALIAS" \
+    --argjson keySize  "$KEY_SIZE" \
+    '{
+        tokenProfileAttributes: [],
+        createKeyAttributes: [
+            {uuid: $aliasUuid, name: "data_keyAlias",     contentType: "string",
+             version: "v2", content: [{data: $keyAlias}]},
+            {uuid: $algUuid,   name: "data_keyAlgorithm", contentType: "string",
+             version: "v2", content: [{reference: "RSA", data: "RSA"}]},
+            {uuid: $sizeUuid,  name: "data_rsaKeySize",   contentType: "integer",
+             version: "v2", content: [{reference: ("RSA_" + ($keySize|tostring)), data: $keySize}]}
+        ]
+    }')
+
+CREATE_KEY_RESP=$(connector_curl POST \
+    "/v1/cryptographyProvider/tokens/${TOKEN_UUID}/keys/pair" "$CREATE_KEY_BODY") \
+    || die "Key pair creation failed."
+
+PRIVATE_KEY_UUID=$(echo "$CREATE_KEY_RESP" | jq -r '.privateKeyData.uuid // empty')
+PUBLIC_KEY_UUID=$(echo  "$CREATE_KEY_RESP" | jq -r '.publicKeyData.uuid  // empty')
+[[ -n "$PRIVATE_KEY_UUID" ]] || die "Private key UUID missing. Response: $CREATE_KEY_RESP"
+[[ -n "$PUBLIC_KEY_UUID"  ]] || die "Public key UUID missing.  Response: $CREATE_KEY_RESP"
+echo "  Private key UUID : $PRIVATE_KEY_UUID"
+echo "  Public  key UUID : $PUBLIC_KEY_UUID"
+
+# ─── Step 5: Sign ─────────────────────────────────────────────────────────────
+#
+# The connector's CryptographicOperationsController has no attribute-definition
+# endpoint for sign/cipher operations — per the interface source comment:
+# "Attributes for Cipher and Signature is controlled by core."
+# The connector matches signatureAttributes by name (not UUID), so no UUID
+# discovery is needed here.
+
+echo ""
+echo "=== Step 5: Sign (scheme: ${SIG_SCHEME}, digest: ${DIGEST}) ==="
+
+SIGN_BODY=$(jq -n \
+    --arg scheme "$SIG_SCHEME" \
+    --arg digest "$DIGEST" \
+    --arg data   "$DATA_B64" \
+    '{
+        signatureAttributes: [
+            {name: "data_rsaSigScheme", contentType: "string", version: "v2",
+             content: [{data: $scheme}]},
+            {name: "data_sigDigest",    contentType: "string", version: "v2",
+             content: [{data: $digest}]}
+        ],
+        data: [{data: $data}]
+    }')
+
+SIGN_RESP=$(connector_curl POST \
+    "/v1/cryptographyProvider/tokens/${TOKEN_UUID}/keys/${PRIVATE_KEY_UUID}/sign" \
+    "$SIGN_BODY") || die "Sign request failed."
+
+SIGNATURE=$(echo "$SIGN_RESP" | jq -r '.signatures[0].data // empty')
+[[ -n "$SIGNATURE" ]] || die "Signature missing from response: $SIGN_RESP"
+echo "  Signature (base64): ${SIGNATURE}"
+
+echo ""
+echo "=== Sign operation successful ==="
+# Cleanup runs automatically via trap EXIT.

--- a/src/main/java/com/czertainly/cp/soft/dao/entity/KeyData.java
+++ b/src/main/java/com/czertainly/cp/soft/dao/entity/KeyData.java
@@ -43,7 +43,7 @@ public class KeyData extends UniquelyIdentified {
     @Column(name = "metadata", length = Integer.MAX_VALUE)
     private String metadata;
 
-    @ManyToOne()
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "token_instance_uuid", insertable = false, updatable = false)
     private TokenInstance tokenInstance;
 

--- a/src/main/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsServiceImpl.java
@@ -131,12 +131,18 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
     @Override
     public DecryptDataResponseDto decryptData(UUID uuid, UUID keyUuid, CipherDataRequestDto request) throws NotFoundException {
         KeyData key = keyManagementService.getKeyEntity(uuid, keyUuid);
+        if (key.getType() != KeyType.PRIVATE_KEY) {
+            throw new CryptographicOperationException("Only private keys can be used for decryption.");
+        }
         return CipherUtil.decrypt(request, key);
     }
 
     @Override
     public EncryptDataResponseDto encryptData(UUID uuid, UUID keyUuid, CipherDataRequestDto request) throws NotFoundException {
         KeyData key = keyManagementService.getKeyEntity(uuid, keyUuid);
+        if (key.getType() != KeyType.PUBLIC_KEY) {
+            throw new CryptographicOperationException("Only public keys can be used for encryption.");
+        }
         return CipherUtil.encrypt(request, key);
     }
 }

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
@@ -101,7 +101,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 publicKey = createAndSaveKeyData(
                         alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.RSA, KeyFormat.SPKI,
                         KeyStoreUtil.spkiKeyValueFromKeyStore(keyStore, alias),
-                        keySize, metadata, tokenInstance.getUuid());
+                        keySize, metadata, tokenInstance);
 
                 // create private key
                 CustomKeyValue customKeyValue = new CustomKeyValue();
@@ -110,7 +110,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 customKeyValue.setValues(customKeyValues);
 
                 privateKey = createAndSaveKeyData(alias, association, KeyType.PRIVATE_KEY, KeyAlgorithm.RSA,
-                        KeyFormat.CUSTOM, customKeyValue, keySize, metadata, tokenInstance.getUuid());
+                        KeyFormat.CUSTOM, customKeyValue, keySize, metadata, tokenInstance);
             }
             case ECDSA -> {
                 final EcdsaCurveName curveName = EcdsaCurveName.valueOf(
@@ -125,7 +125,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 publicKey = createAndSaveKeyData(
                         alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.ECDSA, KeyFormat.SPKI,
                         KeyStoreUtil.spkiKeyValueFromKeyStore(keyStore, alias),
-                        curveName.getSize()*2, metadata, tokenInstance.getUuid());
+                        curveName.getSize()*2, metadata, tokenInstance);
 
                 // create private key
                 CustomKeyValue customKeyValue = new CustomKeyValue();
@@ -135,7 +135,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 customKeyValue.setValues(customKeyValues);
 
                 privateKey = createAndSaveKeyData(alias, association, KeyType.PRIVATE_KEY, KeyAlgorithm.ECDSA,
-                        KeyFormat.CUSTOM, customKeyValue, curveName.getSize(), metadata, tokenInstance.getUuid());
+                        KeyFormat.CUSTOM, customKeyValue, curveName.getSize(), metadata, tokenInstance);
 
             }
             case FALCON -> {
@@ -153,7 +153,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 publicKey = createAndSaveKeyData(
                         alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.FALCON, KeyFormat.SPKI,
                         KeyStoreUtil.spkiKeyValueFromKeyStore(keyStore, alias),
-                        falconDegree.getPublicKeySize(), metadata, tokenInstance.getUuid());
+                        falconDegree.getPublicKeySize(), metadata, tokenInstance);
 
                 CustomKeyValue customKeyValue = new CustomKeyValue();
                 HashMap<String, String> customKeyValues = new HashMap<>();
@@ -162,7 +162,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
 
                 // prepare private key
                 privateKey = createAndSaveKeyData(alias, association, KeyType.PRIVATE_KEY, KeyAlgorithm.FALCON,
-                        KeyFormat.CUSTOM, customKeyValue, falconDegree.getPrivateKeySize(), metadata, tokenInstance.getUuid());
+                        KeyFormat.CUSTOM, customKeyValue, falconDegree.getPrivateKeySize(), metadata, tokenInstance);
             }
             case MLDSA -> {
                 final MLDSASecurityCategory level = MLDSASecurityCategory.valueOf(
@@ -182,7 +182,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 publicKey = createAndSaveKeyData(
                         alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.MLDSA, KeyFormat.SPKI,
                         KeyStoreUtil.spkiKeyValueFromPrivateKey(keyStore, alias, tokenInstance.getCode()),
-                        level.getPublicKeySize(), metadata, tokenInstance.getUuid());
+                        level.getPublicKeySize(), metadata, tokenInstance);
 
                 CustomKeyValue customKeyValue = new CustomKeyValue();
                 HashMap<String, String> customKeyValues = new HashMap<>();
@@ -192,7 +192,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
 
                 // prepare private key
                 privateKey = createAndSaveKeyData(alias, association, KeyType.PRIVATE_KEY, KeyAlgorithm.MLDSA,
-                        KeyFormat.CUSTOM, customKeyValue, level.getPrivateKeySize(), metadata, tokenInstance.getUuid());
+                        KeyFormat.CUSTOM, customKeyValue, level.getPrivateKeySize(), metadata, tokenInstance);
             }
             case SLHDSA -> {
                 final SLHDSAHash hash = SLHDSAHash.valueOf(
@@ -225,7 +225,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                         alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.SLHDSA, KeyFormat.SPKI,
                         //KeyStoreUtil.spkiKeyValueFromPrivateKey(keyStore, alias, tokenInstance.getCode()),
                         KeyStoreUtil.spkiKeyValueFromKeyStore(keyStore, alias),
-                        slhDsaSecurityCategory.getPublicKeySize(), metadata, tokenInstance.getUuid());
+                        slhDsaSecurityCategory.getPublicKeySize(), metadata, tokenInstance);
 
                 CustomKeyValue customKeyValue = new CustomKeyValue();
                 HashMap<String, String> customKeyValues = new HashMap<>();
@@ -237,7 +237,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
 
                 // prepare private key
                 privateKey = createAndSaveKeyData(alias, association, KeyType.PRIVATE_KEY, KeyAlgorithm.SLHDSA,
-                        KeyFormat.CUSTOM, customKeyValue, slhDsaSecurityCategory.getPrivateKeySize(), metadata, tokenInstance.getUuid());
+                        KeyFormat.CUSTOM, customKeyValue, slhDsaSecurityCategory.getPrivateKeySize(), metadata, tokenInstance);
             }
             case MLKEM -> {
                 final MLKEMSecurityCategory securityCategory = MLKEMSecurityCategory.valueOf(
@@ -248,7 +248,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
 
                 BCMLKEMPublicKey kemPublicKey =  KeyStoreUtil.generateMLKEMKey(keyStore, alias, securityCategory, tokenInstance.getCode());
                 RawKeyValue keyValue = new RawKeyValue(Base64.getEncoder().encodeToString(kemPublicKey.getEncoded()));
-                publicKey = createAndSaveKeyData(alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.MLKEM, KeyFormat.SPKI, keyValue, securityCategory.getPublicKeySize(), metadata, tokenInstance.getUuid());
+                publicKey = createAndSaveKeyData(alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.MLKEM, KeyFormat.SPKI, keyValue, securityCategory.getPublicKeySize(), metadata, tokenInstance);
 
                 CustomKeyValue customKeyValue = new CustomKeyValue();
                 HashMap<String, String> customKeyValues = new HashMap<>();
@@ -257,7 +257,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
 
                 // prepare private key
                 privateKey = createAndSaveKeyData(alias, association, KeyType.PRIVATE_KEY, KeyAlgorithm.MLKEM,
-                        KeyFormat.CUSTOM, customKeyValue, securityCategory.getPrivateKeySize(), metadata, tokenInstance.getUuid());
+                        KeyFormat.CUSTOM, customKeyValue, securityCategory.getPrivateKeySize(), metadata, tokenInstance);
 
             }
             default -> throw new IllegalArgumentException("Unsupported algorithm: " + algorithm);
@@ -342,7 +342,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
             KeyValue value,
             int length,
             List<MetadataAttribute> metadata,
-            UUID tokenInstanceUuid) {
+            TokenInstance tokenInstance) {
         KeyData keyData = new KeyData();
         keyData.setUuid(UUID.randomUUID());
         keyData.setName(alias);
@@ -353,7 +353,7 @@ public class KeyManagementServiceImpl implements KeyManagementService {
         keyData.setValue(value);
         keyData.setLength(length);
         keyData.setMetadata(metadata);
-        keyData.setTokenInstanceUuid(tokenInstanceUuid);
+        keyData.setTokenInstance(tokenInstance);
 
         keyDataRepository.save(keyData);
 

--- a/src/main/java/com/czertainly/cp/soft/util/CipherUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/CipherUtil.java
@@ -16,22 +16,34 @@ import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.cp.soft.attribute.RsaCipherAttributes;
 import com.czertainly.cp.soft.dao.entity.KeyData;
 import com.czertainly.cp.soft.exception.NotSupportedException;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
 import java.security.*;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
 import java.util.*;
 
 public class CipherUtil {
+
+    /**
+     * Bundles a JCE transformation string with an optional {@link AlgorithmParameterSpec}.
+     * The parameter spec is non-null only when the transformation string alone is not sufficient to fully describe
+     * the cipher configuration (such as OAEP with a MGF1 hash that differs from the main digest hash).
+     */
+    private record CipherSpec(String transformation, AlgorithmParameterSpec parameterSpec) {}
 
     public static DecryptDataResponseDto decrypt(CipherDataRequestDto request, KeyData key) {
         switch (key.getAlgorithm()) {
             case RSA -> {
                 List<RequestAttribute> attributes = request.getCipherAttributes();
                 RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
-                return decryptData(request, key, getCipherTransformation(rsaEncryptionScheme, request.getCipherAttributes()));
+                return decryptData(request, key, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
             }
             default -> throw new NotSupportedException("Algorithm not supported");
         }
@@ -42,79 +54,99 @@ public class CipherUtil {
             case RSA -> {
                 List<RequestAttribute> attributes = request.getCipherAttributes();
                 RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
-                return encryptData(request, key, getCipherTransformation(rsaEncryptionScheme, request.getCipherAttributes()));
+                return encryptData(request, key, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
             }
             default -> throw new NotSupportedException("Algorithm not supported");
         }
     }
 
-    private static String getCipherTransformation(RsaEncryptionScheme rsaEncryptionScheme, List<RequestAttribute> attributes) {
-        String transformation;
-        if(rsaEncryptionScheme.equals(RsaEncryptionScheme.PKCS1_v1_5)) {
-            transformation = framePkcs1Scheme();
+    private static DecryptDataResponseDto decryptData(CipherDataRequestDto request, KeyData key, CipherSpec cipherSpec) {
+        DecryptDataResponseDto responseDto = new DecryptDataResponseDto();
+        responseDto.setDecryptedData(doProcess(request.getCipherData(), Cipher.DECRYPT_MODE, cipherSpec, key));
+        return responseDto;
+    }
+
+    private static EncryptDataResponseDto encryptData(CipherDataRequestDto request, KeyData key, CipherSpec cipherSpec) {
+        EncryptDataResponseDto responseDto = new EncryptDataResponseDto();
+        responseDto.setEncryptedData(doProcess(request.getCipherData(), Cipher.ENCRYPT_MODE, cipherSpec, key));
+        return responseDto;
+    }
+
+    private static List<CipherResponseData> doProcess(List<CipherRequestData> cipherData, int mode,
+                                                      CipherSpec cipherSpec, KeyData key) {
+        Iterator<CipherRequestData> it = cipherData.stream().iterator();
+        List<CipherResponseData> responseDataList = new ArrayList<>();
+        while (it.hasNext()) {
+            try {
+                byte[] encBytes = it.next().getData();
+                Cipher cipher = Cipher.getInstance(cipherSpec.transformation(), BouncyCastleProvider.PROVIDER_NAME);
+                // RSA encryption must use the public key; decryption must use the private key.
+                Key cryptoKey = (mode == Cipher.ENCRYPT_MODE)
+                        ? KeyStoreUtil.getCertificate(key).getPublicKey()
+                        : KeyStoreUtil.getPrivateKey(key);
+                if (cipherSpec.parameterSpec() != null) {
+                    cipher.init(mode, cryptoKey, cipherSpec.parameterSpec());
+                } else {
+                    cipher.init(mode, cryptoKey);
+                }
+                CipherResponseData cipherResponseData = new CipherResponseData();
+                cipherResponseData.setData(cipher.doFinal(encBytes));
+                responseDataList.add(cipherResponseData);
+            } catch (NoSuchAlgorithmException | NoSuchPaddingException | NoSuchProviderException |
+                     InvalidKeyException | InvalidAlgorithmParameterException |
+                     IllegalBlockSizeException | BadPaddingException e) {
+                throw new ValidationException(ValidationError.create("Exception when processing cipher data: " + e.getMessage()));
+            }
+        }
+        return responseDataList;
+    }
+
+    private static CipherSpec getCipherSpec(RsaEncryptionScheme rsaEncryptionScheme, List<RequestAttribute> attributes) {
+        if (rsaEncryptionScheme.equals(RsaEncryptionScheme.PKCS1_v1_5)) {
+            return new CipherSpec("RSA/NONE/PKCS1Padding", null);
         } else if (rsaEncryptionScheme.equals(RsaEncryptionScheme.OAEP)) {
             try {
                 DigestAlgorithm hash = DigestAlgorithm.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_OAEP_HASH_NAME, attributes, StringAttributeContentV2.class).getData());
                 boolean useMgf = AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_OAEP_USE_MGF_NAME, attributes, BooleanAttributeContentV2.class).getData();
-                transformation = frameOaepTransformation(hash, useMgf);
+                return buildOaepCipherSpec(hash, useMgf);
             } catch (Exception e) {
                 throw new ValidationException("Invalid attributes for OAEP");
             }
         } else {
             throw new NotSupportedException("Transformation type not supported");
         }
-        return transformation;
     }
 
-    private static String framePkcs1Scheme() {
-        return "RSA/NONE/PKCS1Padding";
-    }
-
-    private static String frameOaepTransformation(DigestAlgorithm hash, boolean useMgf){
-        return "RSA/NONE/OAEPWith" + hash.getProviderName() + (useMgf ? "AndMGF1Padding": "Padding");
-    }
-
-    private static DecryptDataResponseDto decryptData(CipherDataRequestDto request, KeyData key, String transformation) {
-        DecryptDataResponseDto responseDto = new DecryptDataResponseDto();
-        responseDto.setDecryptedData(doProcess(
-                request.getCipherData(),
-                Cipher.DECRYPT_MODE,
-                transformation,
-                key
-        ));
-        return responseDto;
-    }
-
-    private static EncryptDataResponseDto encryptData(CipherDataRequestDto request, KeyData key, String transformation) {
-        EncryptDataResponseDto responseDto = new EncryptDataResponseDto();
-        responseDto.setEncryptedData(doProcess(
-                request.getCipherData(),
-                Cipher.ENCRYPT_MODE,
-                transformation,
-                key
-        ));
-        return responseDto;
-    }
-
-    private static List<CipherResponseData> doProcess(List<CipherRequestData> cipherData, int mode, String transformation, KeyData key) {
-        Iterator<CipherRequestData> cipherRequestDataIterator = cipherData.stream().iterator();
-        List<CipherResponseData> responseDataList = new ArrayList<>();
-        while (cipherRequestDataIterator.hasNext()) {
-            try {
-                byte[] encBytes = cipherRequestDataIterator.next().getData();
-                Cipher cipher = Cipher.getInstance(transformation);
-                cipher.init(mode, KeyStoreUtil.getPrivateKey(key));
-
-                byte[] decBytes = cipher.doFinal(encBytes);
-
-                CipherResponseData cipherResponseData = new CipherResponseData();
-                cipherResponseData.setData(decBytes);
-                responseDataList.add(cipherResponseData);
-            } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException |
-                     IllegalBlockSizeException | BadPaddingException e) {
-                throw new ValidationException(ValidationError.create("Exception when decrypting data. Exception is :" + e.getMessage()));
-            }
+    /**
+     * Builds the {@link CipherSpec} for RSA-OAEP.
+     *
+     * <p>When {@code useMgf} is {@code true} the same digest algorithm is used for both the OAEP hash and MGF1
+     * — expressed entirely through the JCE transformation string (such as {@code RSA/NONE/OAEPWithSHA256AndMGF1Padding}).
+     *
+     * <p>When {@code useMgf} is {@code false} the specified digest is used only for the OAEP hash while MGF1 falls back
+     * to SHA-1, which is the default defined in RFC 8017 §7.1. Because no JCE transformation string exists for this split-hash
+     * variant, the same transformation string is reused but an explicit
+     * {@link OAEPParameterSpec} is attached that overrides the MGF1 hash to SHA-1.
+     */
+    private static CipherSpec buildOaepCipherSpec(DigestAlgorithm hash, boolean useMgf) {
+        String transformation = "RSA/NONE/OAEPWith" + hash.getProviderName() + "AndMGF1Padding";
+        if (useMgf) {
+            // Hash and MGF1 both use the specified digest — transformation string is sufficient.
+            return new CipherSpec(transformation, null);
+        } else {
+            // Hash uses the specified digest; MGF1 uses SHA-1 (RFC 8017 default).
+            OAEPParameterSpec spec = new OAEPParameterSpec(
+                    toJcaHashName(hash), "MGF1", MGF1ParameterSpec.SHA1, PSource.PSpecified.DEFAULT);
+            return new CipherSpec(transformation, spec);
         }
-        return responseDataList;
+    }
+
+    private static String toJcaHashName(DigestAlgorithm hash) {
+        return switch (hash) {
+            case SHA_256 -> "SHA-256";
+            case SHA_384 -> "SHA-384";
+            case SHA_512 -> "SHA-512";
+            default -> throw new NotSupportedException("Hash algorithm not supported for OAEP: " + hash);
+        };
     }
 }

--- a/src/main/java/com/czertainly/cp/soft/util/DatabaseMigration.java
+++ b/src/main/java/com/czertainly/cp/soft/util/DatabaseMigration.java
@@ -45,7 +45,7 @@ public class DatabaseMigration {
     @SuppressWarnings("java:S115")
     public enum JavaMigrationChecksums {
         V202505121340__DeactivateTokensWithDeprecatedAlgorithms(1269234600),
-        V202604211200__MigrateMLKEMKeyStorageFormat(-601477426);
+        V202604211200__MigrateMLKEMKeyStorageFormat(187817644);
 
         private final int checksum;
 

--- a/src/main/java/com/czertainly/cp/soft/util/DatabaseMigration.java
+++ b/src/main/java/com/czertainly/cp/soft/util/DatabaseMigration.java
@@ -44,7 +44,8 @@ public class DatabaseMigration {
      */
     @SuppressWarnings("java:S115")
     public enum JavaMigrationChecksums {
-        V202505121340__DeactivateTokensWithDeprecatedAlgorithms(1269234600);
+        V202505121340__DeactivateTokensWithDeprecatedAlgorithms(1269234600),
+        V202604211200__MigrateMLKEMKeyStorageFormat(-827819411);
 
         private final int checksum;
 

--- a/src/main/java/com/czertainly/cp/soft/util/DatabaseMigration.java
+++ b/src/main/java/com/czertainly/cp/soft/util/DatabaseMigration.java
@@ -45,7 +45,7 @@ public class DatabaseMigration {
     @SuppressWarnings("java:S115")
     public enum JavaMigrationChecksums {
         V202505121340__DeactivateTokensWithDeprecatedAlgorithms(1269234600),
-        V202604211200__MigrateMLKEMKeyStorageFormat(-827819411);
+        V202604211200__MigrateMLKEMKeyStorageFormat(-601477426);
 
         private final int checksum;
 

--- a/src/main/java/com/czertainly/cp/soft/util/KeyStoreUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/KeyStoreUtil.java
@@ -4,18 +4,12 @@ import com.czertainly.api.model.connector.cryptography.key.value.SpkiKeyValue;
 import com.czertainly.cp.soft.collection.*;
 import com.czertainly.cp.soft.dao.entity.KeyData;
 import com.czertainly.cp.soft.exception.TokenInstanceException;
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
 import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
 import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
 import org.bouncycastle.jcajce.spec.SLHDSAParameterSpec;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PKCS8Generator;
-import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
-import org.bouncycastle.operator.*;
-import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
-import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfoBuilder;
 import org.bouncycastle.pqc.jcajce.spec.FalconParameterSpec;
 
 import java.io.ByteArrayInputStream;
@@ -40,7 +34,7 @@ public class KeyStoreUtil {
 
     public static byte[] createNewKeystore(String type, String code) {
         try {
-            KeyStore ks = KeyStore.getInstance(type);
+            KeyStore ks = KeyStore.getInstance(type, BouncyCastleProvider.PROVIDER_NAME);
             char[] password = code.toCharArray();
             ks.load(null, password);
 
@@ -57,6 +51,8 @@ public class KeyStoreUtil {
             throw new IllegalStateException(CANNOT_CREATE_NEW_KEY_STORE, e);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(INVALID_ALGORITHM_FOR_KEY_STORE, e);
+        } catch (NoSuchProviderException e) {
+            throw new IllegalStateException(PROVIDER_NOT_FOUND, e);
         }
     }
 
@@ -82,7 +78,7 @@ public class KeyStoreUtil {
 
     public static KeyStore loadKeystore(byte[] data, String code) {
         try {
-            KeyStore ks = KeyStore.getInstance("PKCS12");
+            KeyStore ks = KeyStore.getInstance("PKCS12", BouncyCastleProvider.PROVIDER_NAME);
             char[] password = code.toCharArray();
             ks.load(new ByteArrayInputStream(data), password);
             return ks;
@@ -91,9 +87,11 @@ public class KeyStoreUtil {
         } catch (KeyStoreException e) {
             throw new IllegalStateException(INVALID_KEY_STORE, e);
         } catch (IOException e) {
-            throw new IllegalStateException("Cannot instantiate KeyStore: " + e.getCause().getMessage(), e);
+            throw new IllegalStateException("Cannot instantiate KeyStore: " + e.getMessage(), e);
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(INVALID_ALGORITHM_FOR_KEY_STORE, e);
+        } catch (NoSuchProviderException e) {
+            throw new IllegalStateException(PROVIDER_NOT_FOUND, e);
         }
     }
 
@@ -265,13 +263,10 @@ public class KeyStoreUtil {
 
             KeyPair keyPair = keyPairGenerator.generateKeyPair();
 
-            // Store Private Key as Encrypted Private Key Info
-            byte[] encoded = keyPair.getPrivate().getEncoded();
-            PrivateKeyInfo originalInfo = PrivateKeyInfo.getInstance(encoded);
-            JceOpenSSLPKCS8EncryptorBuilder encryptorBuilder = new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.PBE_SHA1_3DES).setPassword(password.toCharArray());
-            OutputEncryptor oe = encryptorBuilder.build();
-            PKCS8EncryptedPrivateKeyInfo encryptedPrivateKeyInfo = new PKCS8EncryptedPrivateKeyInfoBuilder(originalInfo).build(oe);
-            keyStore.setKeyEntry(alias, encryptedPrivateKeyInfo.getEncoded(), null);
+            final X509Certificate cert = X509Util.generateMLKEMOrphanX509Certificate(keyPair);
+            final X509Certificate[] chain = new X509Certificate[]{cert};
+
+            keyStore.setKeyEntry(alias, keyPair.getPrivate(), password.toCharArray(), chain);
 
             PublicKey publicKey = keyPair.getPublic();
             if (!(publicKey instanceof BCMLKEMPublicKey)) {
@@ -283,15 +278,10 @@ public class KeyStoreUtil {
             throw new IllegalStateException("ML-KEM algorithm not found", e);
         } catch (NoSuchProviderException e) {
             throw new IllegalStateException(PROVIDER_NOT_FOUND, e);
-
         } catch (InvalidAlgorithmParameterException e) {
             throw new IllegalStateException("Invalid ML-KEM algorithm parameters", e);
         } catch (KeyStoreException e) {
             throw new IllegalStateException("Cannot generate ML-KEM key", e);
-        } catch (IOException e) {
-            throw new IllegalStateException("Cannot generate ML-KEM Private Key Info", e);
-        } catch (OperatorCreationException e) {
-            throw new IllegalStateException("Cannot build encryptor for ML-KEM Private Key Info", e);
         }
     }
 

--- a/src/main/java/com/czertainly/cp/soft/util/X509Util.java
+++ b/src/main/java/com/czertainly/cp/soft/util/X509Util.java
@@ -19,6 +19,7 @@ import java.security.cert.X509Certificate;
 import java.util.Date;
 
 public class X509Util {
+    private static final SecureRandom random = new SecureRandom();
 
     public static X509Certificate generateRsaOrphanX509Certificate(KeyPair keyPair) {;
         return generateOrphanX509Certificate(keyPair, "SHA512WithRSAEncryption", BouncyCastleProvider.PROVIDER_NAME);
@@ -52,7 +53,6 @@ public class X509Util {
             ecKpg.initialize(new java.security.spec.ECGenParameterSpec("P-256"));
             KeyPair signingPair = ecKpg.generateKeyPair();
 
-            SecureRandom random = new SecureRandom();
             X500Name owner = new X500Name("CN=generatedCertificate,O=orphan");
 
             final Date notBefore = new Date(System.currentTimeMillis() - 86400000L * 365);
@@ -85,8 +85,6 @@ public class X509Util {
     }
 
     public static X509Certificate generateOrphanX509Certificate(KeyPair keyPair, String signatureAlgorithm, String provider) {
-        SecureRandom random = new SecureRandom();
-
         X500Name owner = new X500Name("CN=generatedCertificate,O=orphan");
 
         // current time minus 1 year, just in case software clock goes back due to time synchronization

--- a/src/main/java/com/czertainly/cp/soft/util/X509Util.java
+++ b/src/main/java/com/czertainly/cp/soft/util/X509Util.java
@@ -38,6 +38,52 @@ public class X509Util {
         }
     }
 
+    /**
+     * ML-KEM is a KEM, not a signing algorithm, so it cannot self-sign an X.509 certificate. We generate
+     * an orphan certificate signed by an ephemeral EC key that embeds the ML-KEM public key in its SubjectPublicKeyInfo.
+     *
+     * <p>The ephemeral EC key is intentionally unverifiable (the signing key is discarded immediately) and
+     * must NEVER be used as a trust anchor.</p>
+     */
+    public static X509Certificate generateMLKEMOrphanX509Certificate(KeyPair mlkemKeyPair) {
+        try {
+            // ML-KEM cannot sign; generate a short-lived EC key pair just for signing the cert.
+            KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+            ecKpg.initialize(new java.security.spec.ECGenParameterSpec("P-256"));
+            KeyPair signingPair = ecKpg.generateKeyPair();
+
+            SecureRandom random = new SecureRandom();
+            X500Name owner = new X500Name("CN=generatedCertificate,O=orphan");
+
+            final Date notBefore = new Date(System.currentTimeMillis() - 86400000L * 365);
+            final Date notAfter  = new Date(System.currentTimeMillis() + 86400000L * 365 * 30);
+
+            // Embed the ML-KEM public key in the certificate's SubjectPublicKeyInfo.
+            X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                    owner, new BigInteger(64, random), notBefore, notAfter, owner, mlkemKeyPair.getPublic());
+
+            ContentSigner signer = new JcaContentSignerBuilder("SHA256WithECDSA")
+                    .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                    .build(signingPair.getPrivate());
+
+            X509CertificateHolder certHolder = builder.build(signer);
+            return new JcaX509CertificateConverter()
+                    .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                    .getCertificate(certHolder);
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("EC algorithm not found", e);
+        } catch (NoSuchProviderException e) {
+            throw new IllegalStateException("Provider not found", e);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new IllegalStateException("Invalid EC parameters", e);
+        } catch (OperatorCreationException e) {
+            throw new IllegalStateException("Cannot create content signer", e);
+        } catch (CertificateException e) {
+            throw new IllegalStateException("Error building ML-KEM orphan certificate", e);
+        }
+    }
+
     public static X509Certificate generateOrphanX509Certificate(KeyPair keyPair, String signatureAlgorithm, String provider) {
         SecureRandom random = new SecureRandom();
 
@@ -57,7 +103,7 @@ public class X509Util {
 
             X509CertificateHolder certHolder = builder.build(signer);
             X509Certificate cert = new JcaX509CertificateConverter()
-                    .setProvider(new BouncyCastleProvider())
+                    .setProvider(BouncyCastleProvider.PROVIDER_NAME)
                     .getCertificate(certHolder);
 
             //check so that cert is valid

--- a/src/main/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormat.java
+++ b/src/main/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormat.java
@@ -55,6 +55,7 @@ import java.util.Map;
  * Aliases whose public key cannot be reconstructed are also skipped with a warning; the corresponding private key remains
  * inaccessible until the key pair is recreated.
  */
+@SuppressWarnings("java:S101") // Flyway requires this naming convention (V<version>__<description>)
 public class V202604211200__MigrateMLKEMKeyStorageFormat extends BaseJavaMigration {
 
     private static final Logger logger = LoggerFactory.getLogger(V202604211200__MigrateMLKEMKeyStorageFormat.class);
@@ -235,7 +236,7 @@ public class V202604211200__MigrateMLKEMKeyStorageFormat extends BaseJavaMigrati
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
                     String alias = rs.getString("name");
-                    String valueJson = rs.getString("value");
+                    String valueJson = rs.getString(JSON_VALUE_FIELD);
                     reconstructPublicKey(alias, valueJson, tokenUuid).ifPresent(pk -> result.put(alias, pk));
                 }
             }

--- a/src/main/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormat.java
+++ b/src/main/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormat.java
@@ -40,7 +40,7 @@ import java.util.Map;
  *
  * <p><b>What this migration does.</b>
  * <ol>
- *   <li>Selects every active {@code token_instance} row (those with a non-null {@code code}).</li>
+ *   <li>Selects every {@code token_instance} row (active and deactivated).</li>
  *   <li>Decrypts the keystore password and loads the PKCS12 blob.</li>
  *   <li>For every alias that has no associated certificate (old format) and whose recovered key
  *       algorithm starts with {@code "ML-KEM"}, the entry is identified as needing migration.</li>
@@ -51,7 +51,10 @@ import java.util.Map;
  *   <li>The updated PKCS12 blob is base64-encoded and persisted to {@code token_instance.data}.</li>
  * </ol>
  *
- * <p>Tokens whose keystores cannot be loaded (already deactivated by a prior migration) are skipped with a warning.
+ * <p>Deactivated tokens (those with a {@code null} code) cannot be decrypted and are skipped.
+ * A WARN is logged when such a token is found to contain ML-KEM keys, because those keys will be
+ * unrecoverable if the token is reactivated after an upgrade without first re-running the migration.
+ * Tokens whose keystores cannot be loaded for other reasons are also skipped with a warning.
  * Aliases whose public key cannot be reconstructed are also skipped with a warning; the corresponding private key remains
  * inaccessible until the key pair is recreated.
  */
@@ -82,7 +85,7 @@ public class V202604211200__MigrateMLKEMKeyStorageFormat extends BaseJavaMigrati
 
         try (Statement select = context.getConnection().createStatement()) {
             ResultSet tokens = select.executeQuery(
-                    "SELECT uuid, code, data FROM token_instance WHERE code IS NOT NULL");
+                    "SELECT uuid, code, data FROM token_instance");
 
             String updateSql = "UPDATE token_instance SET data = ? WHERE uuid = ?";
             try (PreparedStatement update = context.getConnection().prepareStatement(updateSql)) {
@@ -108,10 +111,24 @@ public class V202604211200__MigrateMLKEMKeyStorageFormat extends BaseJavaMigrati
                                  ResultSet tokens,
                                  Object tokenUuid,
                                  PreparedStatement update) {
+        String code;
+        try {
+            code = tokens.getString("code");
+        } catch (Exception e) {
+            logger.warn("Cannot read code column for token {}: {}", tokenUuid, e.getMessage());
+            return false;
+        }
+        if (code == null) {
+            if (tokenHasMlkemKeys(context, tokenUuid)) {
+                logger.warn("Token {} is deactivated — its keystore cannot be migrated. "
+                        + "If it holds ML-KEM keys, reactivate and re-run migration before upgrading.", tokenUuid);
+            }
+            return false;
+        }
+
         String password;
         try {
-            password = SecretsUtil.decodeAndDecryptSecretString(
-                    tokens.getString("code"), SecretEncodingVersion.V1);
+            password = SecretsUtil.decodeAndDecryptSecretString(code, SecretEncodingVersion.V1);
         } catch (Exception e) {
             logger.warn("Cannot decrypt password for token {}: {}", tokenUuid, e.getMessage());
             return false;
@@ -244,6 +261,19 @@ public class V202604211200__MigrateMLKEMKeyStorageFormat extends BaseJavaMigrati
             logger.warn("Cannot query key_data for token {}: {}", tokenUuid, e.getMessage());
         }
         return result;
+    }
+
+    private boolean tokenHasMlkemKeys(Context context, Object tokenUuid) {
+        String sql = "SELECT 1 FROM key_data WHERE token_instance_uuid = ? AND algorithm = 'MLKEM' LIMIT 1";
+        try (PreparedStatement ps = context.getConnection().prepareStatement(sql)) {
+            ps.setObject(1, tokenUuid, Types.OTHER);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        } catch (Exception e) {
+            logger.warn("Cannot check ML-KEM keys for token {}: {}", tokenUuid, e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormat.java
+++ b/src/main/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormat.java
@@ -1,0 +1,267 @@
+package db.migration;
+
+import com.czertainly.cp.soft.util.DatabaseMigration;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import com.czertainly.cp.soft.util.SecretEncodingVersion;
+import com.czertainly.cp.soft.util.SecretsUtil;
+import com.czertainly.cp.soft.util.X509Util;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.security.spec.X509EncodedKeySpec;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.Base64;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Migrates ML-KEM private keys from the legacy 1.3.1 storage format to the 1.4.0 format.
+ *
+ * <p><b>Background.</b> In 1.3.1 ML-KEM private keys were stored in the PKCS12 keystore using the
+ * raw-bytes overload of {@code KeyStore.setKeyEntry(alias, byte[], null)}.  That call places a bare
+ * PKCS8 key bag in the PKCS12 file with <em>no</em> accompanying certificate bag, so
+ * {@code KeyStore.getCertificate(alias)} returns {@code null} for those entries.  Starting with 1.4.0,
+ * the provider generates an ephemeral EC-signed orphan X.509 certificate that embeds the ML-KEM
+ * public key (see {@link X509Util#generateMLKEMOrphanX509Certificate}) and stores the key via
+ * {@code KeyStore.setKeyEntry(alias, PrivateKey, password, chain)}. This is inline with all other key material
+ * in the connector. PKCS12 files produced by 1.3.1 fail to load correctly under the 1.4.0 BouncyCastle version
+ * because the key-bag OIDs changed between the draft and the final NIST FIPS 203 standard.
+ *
+ * <p><b>What this migration does.</b>
+ * <ol>
+ *   <li>Selects every active {@code token_instance} row (those with a non-null {@code code}).</li>
+ *   <li>Decrypts the keystore password and loads the PKCS12 blob.</li>
+ *   <li>For every alias that has no associated certificate (old format) and whose recovered key
+ *       algorithm starts with {@code "ML-KEM"}, the entry is identified as needing migration.</li>
+ *   <li>The corresponding ML-KEM public key is fetched from the {@code key_data} table (stored there
+ *       as an SPKI-encoded value when the key pair was originally created).</li>
+ *   <li>A new orphan certificate is generated, the old bare key bag is removed, and a proper
+ *       {@code PrivateKeyEntry} with the certificate chain is written back.</li>
+ *   <li>The updated PKCS12 blob is base64-encoded and persisted to {@code token_instance.data}.</li>
+ * </ol>
+ *
+ * <p>Tokens whose keystores cannot be loaded (already deactivated by a prior migration) are skipped with a warning.
+ * Aliases whose public key cannot be reconstructed are also skipped with a warning; the corresponding private key remains
+ * inaccessible until the key pair is recreated.
+ */
+public class V202604211200__MigrateMLKEMKeyStorageFormat extends BaseJavaMigration {
+
+    private static final Logger logger = LoggerFactory.getLogger(V202604211200__MigrateMLKEMKeyStorageFormat.class);
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /**
+     * The JSON field name used by every {@code KeyValue} subtype (RawKeyValue, SpkiKeyValue, …)
+     * to carry the base64-encoded key material.
+     */
+    private static final String JSON_VALUE_FIELD = "value";
+
+    @Override
+    public Integer getChecksum() {
+        return DatabaseMigration.JavaMigrationChecksums.V202604211200__MigrateMLKEMKeyStorageFormat.getChecksum();
+    }
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        SecretsUtil secretsUtil = new SecretsUtil();
+        String encryptionKey = System.getenv("ENCRYPTION_KEY");
+        secretsUtil.setEncryptionKeyStatic(encryptionKey == null ? "tU)u&N~B{sqQh{imRDl}" : encryptionKey);
+        Security.addProvider(new BouncyCastleProvider());
+
+        try (Statement select = context.getConnection().createStatement()) {
+            ResultSet tokens = select.executeQuery(
+                    "SELECT uuid, code, data FROM token_instance WHERE code IS NOT NULL");
+
+            String updateSql = "UPDATE token_instance SET data = ? WHERE uuid = ?";
+            try (PreparedStatement update = context.getConnection().prepareStatement(updateSql)) {
+                boolean hasBatch = false;
+                while (tokens.next()) {
+                    Object tokenUuid = tokens.getObject("uuid");
+                    if (migrateToken(context, tokens, tokenUuid, update)) {
+                        hasBatch = true;
+                    }
+                }
+                if (hasBatch) {
+                    update.executeBatch();
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private boolean migrateToken(Context context,
+                                 ResultSet tokens,
+                                 Object tokenUuid,
+                                 PreparedStatement update) {
+        String password;
+        try {
+            password = SecretsUtil.decodeAndDecryptSecretString(
+                    tokens.getString("code"), SecretEncodingVersion.V1);
+        } catch (Exception e) {
+            logger.warn("Cannot decrypt password for token {}: {}", tokenUuid, e.getMessage());
+            return false;
+        }
+
+        byte[] keystoreBytes;
+        try {
+            keystoreBytes = Base64.getDecoder().decode(tokens.getString("data"));
+        } catch (Exception e) {
+            logger.warn("Cannot base64-decode keystore data for token {}: {}", tokenUuid, e.getMessage());
+            return false;
+        }
+
+        KeyStore ks;
+        try {
+            ks = KeyStoreUtil.loadKeystore(keystoreBytes, password);
+        } catch (Exception e) {
+            logger.warn("Cannot load keystore for token {}: {} — skipping", tokenUuid, e.getMessage());
+            return false;
+        }
+
+        Map<String, PublicKey> mlkemPublicKeys = loadMlkemPublicKeysFromDb(context, tokenUuid);
+
+        boolean modified = false;
+        try {
+            Enumeration<String> aliases = ks.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+                if (migrateAlias(ks, alias, password, tokenUuid, mlkemPublicKeys)) {
+                    modified = true;
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Error iterating aliases for token {}: {}", tokenUuid, e.getMessage());
+            return false;
+        }
+
+        if (modified) {
+            try {
+                byte[] updatedBytes = KeyStoreUtil.saveKeystore(ks, password);
+                String updatedData = Base64.getEncoder().encodeToString(updatedBytes);
+                update.setString(1, updatedData);
+                update.setObject(2, tokenUuid, Types.OTHER);
+                update.addBatch();
+                logger.info("Queued keystore update for token {}", tokenUuid);
+                return true;
+            } catch (Exception e) {
+                logger.warn("Cannot serialise updated keystore for token {}: {}", tokenUuid, e.getMessage());
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Inspects a single keystore alias.  If it is an old-format ML-KEM entry (private key present, no certificate chain),
+     * migrates it to the new format in-place.
+     *
+     * @return {@code true} if the entry was migrated, {@code false} if it was already up to date or could not be migrated.
+     */
+    private boolean migrateAlias(KeyStore ks,
+                                 String alias,
+                                 String password,
+                                 Object tokenUuid,
+                                 Map<String, PublicKey> mlkemPublicKeys) {
+        try {
+            // New-format entries always have a certificate — skip them.
+            if (ks.getCertificate(alias) != null) {
+                return false;
+            }
+
+            Key key = ks.getKey(alias, password.toCharArray());
+            if (key == null || !key.getAlgorithm().startsWith("ML-KEM")) {
+                // Either not an ML-KEM key or the entry is corrupt; leave it alone.
+                return false;
+            }
+
+            PrivateKey privateKey = (PrivateKey) key;
+            PublicKey publicKey = mlkemPublicKeys.get(alias);
+            if (publicKey == null) {
+                logger.warn(
+                        "No ML-KEM public key found in key_data for alias '{}' in token {}. "
+                                + "The private key entry will not be migrated and will remain inaccessible.",
+                        alias, tokenUuid);
+                return false;
+            }
+
+            KeyPair keyPair = new KeyPair(publicKey, privateKey);
+            X509Certificate orphanCert = X509Util.generateMLKEMOrphanX509Certificate(keyPair);
+
+            // Remove the bare key bag and replace it with a proper PrivateKeyEntry + cert chain.
+            ks.deleteEntry(alias);
+            ks.setKeyEntry(alias, privateKey, password.toCharArray(), new X509Certificate[]{orphanCert});
+
+            logger.info("Migrated ML-KEM key '{}' in token {} to new storage format", alias, tokenUuid);
+            return true;
+
+        } catch (UnrecoverableKeyException e) {
+            logger.warn("Cannot recover key for alias '{}' in token {} (possibly corrupt): {}",
+                    alias, tokenUuid, e.getMessage());
+        } catch (Exception e) {
+            logger.warn("Unexpected error migrating alias '{}' in token {}: {}",
+                    alias, tokenUuid, e.getMessage());
+        }
+        return false;
+    }
+
+    /**
+     * Queries {@code key_data} for all ML-KEM public keys belonging to the given token instance.
+     *
+     * <p>The {@code value} column contains JSON with a {@code "value"} field that holds the base64-encoded
+     * X.509 SubjectPublicKeyInfo (SPKI) bytes. This is the format written by {@code KeyManagementServiceImpl}
+     * when the key pair was originally created.
+     *
+     * @return a map from alias ({@code key_data.name}) to the reconstructed {@link PublicKey}.
+     */
+    private Map<String, PublicKey> loadMlkemPublicKeysFromDb(Context context, Object tokenUuid) {
+        Map<String, PublicKey> result = new HashMap<>();
+        String sql = "SELECT name, value FROM key_data "
+                + "WHERE token_instance_uuid = ? AND algorithm = 'MLKEM' AND type = 'PUBLIC_KEY'";
+        try (PreparedStatement ps = context.getConnection().prepareStatement(sql)) {
+            ps.setObject(1, tokenUuid, Types.OTHER);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    String alias = rs.getString("name");
+                    String valueJson = rs.getString("value");
+                    reconstructPublicKey(alias, valueJson, tokenUuid).ifPresent(pk -> result.put(alias, pk));
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Cannot query key_data for token {}: {}", tokenUuid, e.getMessage());
+        }
+        return result;
+    }
+
+    /**
+     * Parses the stored JSON value and reconstructs an ML-KEM {@link PublicKey}.
+     */
+    private java.util.Optional<PublicKey> reconstructPublicKey(String alias, String valueJson, Object tokenUuid) {
+        try {
+            JsonNode node = OBJECT_MAPPER.readTree(valueJson);
+            JsonNode valueNode = node.get(JSON_VALUE_FIELD);
+            if (valueNode == null || valueNode.isNull()) {
+                logger.warn("Missing '{}' field in key_data JSON for alias '{}', token {}", JSON_VALUE_FIELD, alias, tokenUuid);
+                return java.util.Optional.empty();
+            }
+            byte[] spkiBytes = Base64.getDecoder().decode(valueNode.asText());
+            KeyFactory kf = KeyFactory.getInstance("ML-KEM", BouncyCastleProvider.PROVIDER_NAME);
+            return java.util.Optional.of(kf.generatePublic(new X509EncodedKeySpec(spkiBytes)));
+        } catch (Exception e) {
+            logger.warn("Cannot reconstruct ML-KEM public key for alias '{}', token {}: {}", alias, tokenUuid, e.getMessage());
+            return java.util.Optional.empty();
+        }
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/AbstractCryptographicOperationsTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/AbstractCryptographicOperationsTest.java
@@ -1,0 +1,64 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.cp.soft.attribute.KeyAttributes;
+import com.czertainly.cp.soft.dao.entity.TokenInstance;
+import com.czertainly.cp.soft.dao.repository.TokenInstanceRepository;
+import com.czertainly.cp.soft.service.CryptographicOperationsService;
+import com.czertainly.cp.soft.service.KeyManagementService;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+abstract class AbstractCryptographicOperationsTest {
+
+    protected static final String PASSWORD = "123";
+
+    @Autowired
+    protected KeyManagementService keyManagementService;
+
+    @Autowired
+    protected CryptographicOperationsService cryptographicOperationsService;
+
+    @Autowired
+    protected TokenInstanceRepository tokenInstanceRepository;
+
+    protected TokenInstance tokenInstance;
+
+    @BeforeEach
+    void setUp() {
+        tokenInstance = new TokenInstance();
+        tokenInstance.setCode(PASSWORD);
+        tokenInstance.setData(KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD));
+        tokenInstanceRepository.save(tokenInstance);
+    }
+
+    protected RequestAttributeV2 buildAliasAttribute(String alias) {
+        RequestAttributeV2 keyAlias = new RequestAttributeV2();
+        keyAlias.setName(KeyAttributes.ATTRIBUTE_DATA_KEY_ALIAS);
+        keyAlias.setContentType(AttributeContentType.STRING);
+        keyAlias.setContent(List.of(new StringAttributeContentV2(alias)));
+        return keyAlias;
+    }
+
+    protected RequestAttributeV2 buildAlgorithmAttribute(KeyAlgorithm algorithm) {
+        RequestAttributeV2 keyAlgorithm = new RequestAttributeV2();
+        keyAlgorithm.setName(KeyAttributes.ATTRIBUTE_DATA_KEY_ALGORITHM);
+        keyAlgorithm.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 algorithmContent = new StringAttributeContentV2();
+        algorithmContent.setReference(algorithm.getCode());
+        algorithmContent.setData(algorithm.getCode());
+        keyAlgorithm.setContent(List.of(algorithmContent));
+        return keyAlgorithm;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/AbstractCryptographicOperationsTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/AbstractCryptographicOperationsTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @SpringBootTest

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsEcdsaSignVerifyTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsEcdsaSignVerifyTest.java
@@ -1,0 +1,119 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
+import com.czertainly.cp.soft.attribute.EcdsaKeyAttributes;
+import com.czertainly.cp.soft.collection.EcdsaCurveName;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+class CryptographicOperationsEcdsaSignVerifyTest extends AbstractCryptographicOperationsTest {
+
+    static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(EcdsaCurveName.secp256r1, DigestAlgorithm.SHA_256),
+                Arguments.of(EcdsaCurveName.secp256r1, DigestAlgorithm.SHA_384),
+                Arguments.of(EcdsaCurveName.secp384r1, DigestAlgorithm.SHA_256),
+                Arguments.of(EcdsaCurveName.secp384r1, DigestAlgorithm.SHA_384),
+                Arguments.of(EcdsaCurveName.secp384r1, DigestAlgorithm.SHA_512),
+                Arguments.of(EcdsaCurveName.secp521r1, DigestAlgorithm.SHA_384),
+                Arguments.of(EcdsaCurveName.secp521r1, DigestAlgorithm.SHA_512)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} + {1}")
+    @MethodSource("parameters")
+    void testSignVerifyEcdsa(EcdsaCurveName curve, DigestAlgorithm digest) throws NotFoundException {
+        // Create key pair
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildEcdsaCreateKeyAttributes("test-ecdsa-" + curve.getName(), curve));
+
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        Assertions.assertEquals(KeyAlgorithm.ECDSA, keyPair.getPrivateKeyData().getKeyData().getAlgorithm());
+        Assertions.assertEquals(KeyAlgorithm.ECDSA, keyPair.getPublicKeyData().getKeyData().getAlgorithm());
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        // Sign
+        byte[] plaintext = "Hello, CZERTAINLY!".getBytes();
+        SignDataRequestDto signRequest = new SignDataRequestDto();
+        signRequest.setSignatureAttributes(buildEcdsaSignatureAttributes(digest));
+        signRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+
+        SignDataResponseDto signResponse = cryptographicOperationsService.signData(
+                tokenInstance.getUuid(), privateKeyUuid, signRequest);
+
+        Assertions.assertNotNull(signResponse.getSignatures());
+        Assertions.assertEquals(1, signResponse.getSignatures().size());
+        byte[] signatureBytes = signResponse.getSignatures().get(0).getData();
+        Assertions.assertNotNull(signatureBytes);
+        Assertions.assertTrue(signatureBytes.length > 0);
+        Assertions.assertNull(signResponse.getSignatures().get(0).getDetails());
+
+        // Verify
+        VerifyDataRequestDto verifyRequest = new VerifyDataRequestDto();
+        verifyRequest.setSignatureAttributes(buildEcdsaSignatureAttributes(digest));
+        verifyRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+        verifyRequest.setSignatures(List.of(new SignatureRequestData(signatureBytes, "item-1")));
+
+        VerifyDataResponseDto verifyResponse = cryptographicOperationsService.verifyData(
+                tokenInstance.getUuid(), publicKeyUuid, verifyRequest);
+
+        Assertions.assertNotNull(verifyResponse.getVerifications());
+        Assertions.assertEquals(1, verifyResponse.getVerifications().size());
+        Assertions.assertTrue(verifyResponse.getVerifications().get(0).isResult());
+    }
+
+    private List<RequestAttribute> buildEcdsaCreateKeyAttributes(String alias, EcdsaCurveName curve) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+        attributes.add(buildAliasAttribute(alias));
+        attributes.add(buildAlgorithmAttribute(KeyAlgorithm.ECDSA));
+
+        RequestAttributeV2 curveAttr = new RequestAttributeV2();
+        curveAttr.setName(EcdsaKeyAttributes.ATTRIBUTE_DATA_ECDSA_CURVE);
+        curveAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 curveContent = new StringAttributeContentV2();
+        curveContent.setReference(curve.getName());
+        curveContent.setData(curve.getName());
+        curveAttr.setContent(List.of(curveContent));
+        attributes.add(curveAttr);
+
+        return attributes;
+    }
+
+    private List<RequestAttribute> buildEcdsaSignatureAttributes(DigestAlgorithm digest) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+
+        RequestAttributeV2 digestAttr = new RequestAttributeV2();
+        digestAttr.setName(EcdsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST);
+        digestAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 digestContent = new StringAttributeContentV2();
+        digestContent.setReference(digest.getCode());
+        digestContent.setData(digest.getCode());
+        digestAttr.setContent(List.of(digestContent));
+        attributes.add(digestAttr);
+
+        return attributes;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsFalconSignVerifyTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsFalconSignVerifyTest.java
@@ -1,0 +1,86 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
+import com.czertainly.cp.soft.attribute.FalconKeyAttributes;
+import com.czertainly.cp.soft.collection.FalconDegree;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+class CryptographicOperationsFalconSignVerifyTest extends AbstractCryptographicOperationsTest {
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(FalconDegree.class)
+    void testSignVerifyFalcon(FalconDegree degree) throws NotFoundException {
+        // Create key pair
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildFalconCreateKeyAttributes("test-falcon-" + degree.getDegree(), degree));
+
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        Assertions.assertEquals(KeyAlgorithm.FALCON, keyPair.getPrivateKeyData().getKeyData().getAlgorithm());
+        Assertions.assertEquals(KeyAlgorithm.FALCON, keyPair.getPublicKeyData().getKeyData().getAlgorithm());
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        // Sign
+        byte[] plaintext = "Hello, CZERTAINLY!".getBytes();
+        SignDataRequestDto signRequest = new SignDataRequestDto();
+        signRequest.setSignatureAttributes(List.of());
+        signRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+
+        SignDataResponseDto signResponse = cryptographicOperationsService.signData(
+                tokenInstance.getUuid(), privateKeyUuid, signRequest);
+
+        Assertions.assertNotNull(signResponse.getSignatures());
+        Assertions.assertEquals(1, signResponse.getSignatures().size());
+        byte[] signatureBytes = signResponse.getSignatures().get(0).getData();
+        Assertions.assertNotNull(signatureBytes);
+        Assertions.assertTrue(signatureBytes.length > 0);
+        Assertions.assertNull(signResponse.getSignatures().get(0).getDetails());
+
+        // Verify
+        VerifyDataRequestDto verifyRequest = new VerifyDataRequestDto();
+        verifyRequest.setSignatureAttributes(List.of());
+        verifyRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+        verifyRequest.setSignatures(List.of(new SignatureRequestData(signatureBytes, "item-1")));
+
+        VerifyDataResponseDto verifyResponse = cryptographicOperationsService.verifyData(
+                tokenInstance.getUuid(), publicKeyUuid, verifyRequest);
+
+        Assertions.assertNotNull(verifyResponse.getVerifications());
+        Assertions.assertEquals(1, verifyResponse.getVerifications().size());
+        Assertions.assertTrue(verifyResponse.getVerifications().get(0).isResult());
+    }
+
+    private List<RequestAttribute> buildFalconCreateKeyAttributes(String alias, FalconDegree degree) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+        attributes.add(buildAliasAttribute(alias));
+        attributes.add(buildAlgorithmAttribute(KeyAlgorithm.FALCON));
+
+        RequestAttributeV2 degreeAttr = new RequestAttributeV2();
+        degreeAttr.setName(FalconKeyAttributes.ATTRIBUTE_DATA_FALCON_DEGREE);
+        degreeAttr.setContentType(AttributeContentType.INTEGER);
+        degreeAttr.setContent(List.of(new IntegerAttributeContentV2("FALCON_" + degree.getDegree(), degree.getDegree())));
+        attributes.add(degreeAttr);
+
+        return attributes;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsMldsaSignVerifyTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsMldsaSignVerifyTest.java
@@ -1,0 +1,106 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.BooleanAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
+import com.czertainly.cp.soft.attribute.MLDSAKeyAttributes;
+import com.czertainly.cp.soft.collection.MLDSASecurityCategory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+class CryptographicOperationsMldsaSignVerifyTest extends AbstractCryptographicOperationsTest {
+
+    static Stream<Arguments> parameters() {
+        return Stream.of(
+                Arguments.of(MLDSASecurityCategory.MLDSA_44, false),
+                Arguments.of(MLDSASecurityCategory.MLDSA_65, false),
+                Arguments.of(MLDSASecurityCategory.MLDSA_87, false),
+                Arguments.of(MLDSASecurityCategory.MLDSA_44, true),
+                Arguments.of(MLDSASecurityCategory.MLDSA_65, true),
+                Arguments.of(MLDSASecurityCategory.MLDSA_87, true)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} prehash={1}")
+    @MethodSource("parameters")
+    void testSignVerifyMldsa(MLDSASecurityCategory level, boolean prehash) throws NotFoundException {
+        // Create key pair
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildMldsaCreateKeyAttributes("test-mldsa-" + level.name(), level, prehash));
+
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        Assertions.assertEquals(KeyAlgorithm.MLDSA, keyPair.getPrivateKeyData().getKeyData().getAlgorithm());
+        Assertions.assertEquals(KeyAlgorithm.MLDSA, keyPair.getPublicKeyData().getKeyData().getAlgorithm());
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        // Sign
+        byte[] plaintext = "Hello, CZERTAINLY!".getBytes();
+        SignDataRequestDto signRequest = new SignDataRequestDto();
+        signRequest.setSignatureAttributes(List.of());
+        signRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+
+        SignDataResponseDto signResponse = cryptographicOperationsService.signData(
+                tokenInstance.getUuid(), privateKeyUuid, signRequest);
+
+        Assertions.assertNotNull(signResponse.getSignatures());
+        Assertions.assertEquals(1, signResponse.getSignatures().size());
+        byte[] signatureBytes = signResponse.getSignatures().get(0).getData();
+        Assertions.assertNotNull(signatureBytes);
+        Assertions.assertTrue(signatureBytes.length > 0);
+        Assertions.assertNull(signResponse.getSignatures().get(0).getDetails());
+
+        // Verify
+        VerifyDataRequestDto verifyRequest = new VerifyDataRequestDto();
+        verifyRequest.setSignatureAttributes(List.of());
+        verifyRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+        verifyRequest.setSignatures(List.of(new SignatureRequestData(signatureBytes, "item-1")));
+
+        VerifyDataResponseDto verifyResponse = cryptographicOperationsService.verifyData(
+                tokenInstance.getUuid(), publicKeyUuid, verifyRequest);
+
+        Assertions.assertNotNull(verifyResponse.getVerifications());
+        Assertions.assertEquals(1, verifyResponse.getVerifications().size());
+        Assertions.assertTrue(verifyResponse.getVerifications().get(0).isResult());
+    }
+
+    private List<RequestAttribute> buildMldsaCreateKeyAttributes(String alias, MLDSASecurityCategory level, boolean prehash) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+        attributes.add(buildAliasAttribute(alias));
+        attributes.add(buildAlgorithmAttribute(KeyAlgorithm.MLDSA));
+
+        RequestAttributeV2 levelAttr = new RequestAttributeV2();
+        levelAttr.setName(MLDSAKeyAttributes.ATTRIBUTE_DATA_MLDSA_LEVEL);
+        levelAttr.setContentType(AttributeContentType.INTEGER);
+        levelAttr.setContent(List.of(new IntegerAttributeContentV2(level.name(), level.getNistSecurityCategory())));
+        attributes.add(levelAttr);
+
+        RequestAttributeV2 prehashAttr = new RequestAttributeV2();
+        prehashAttr.setName(MLDSAKeyAttributes.ATTRIBUTE_DATA_MLDSA_PREHASH);
+        prehashAttr.setContentType(AttributeContentType.BOOLEAN);
+        prehashAttr.setContent(List.of(new BooleanAttributeContentV2(prehash)));
+        attributes.add(prehashAttr);
+
+        return attributes;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRandomDataTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRandomDataTest.java
@@ -1,0 +1,39 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.model.connector.cryptography.operations.RandomDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.RandomDataResponseDto;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Transactional
+class CryptographicOperationsRandomDataTest extends AbstractCryptographicOperationsTest {
+
+    @ParameterizedTest(name = "{0} bytes")
+    @ValueSource(ints = {16, 32, 64, 256})
+    void testRandomData(int requestedLength) {
+        RandomDataRequestDto request = new RandomDataRequestDto();
+        request.setLength(requestedLength);
+
+        RandomDataResponseDto response = cryptographicOperationsService.randomData(tokenInstance.getUuid().toString(), request);
+
+        Assertions.assertNotNull(response, "Response should not be null");
+        Assertions.assertNotNull(response.getData(), "Response data should not be null");
+        Assertions.assertEquals(requestedLength, response.getData().length,
+                "Data length should match requested length");
+        Assertions.assertFalse(isAllZeros(response.getData()),
+                "Data should not be all zeros (probabilistic sanity check)");
+    }
+
+    private boolean isAllZeros(byte[] data) {
+        for (byte b : data) {
+            if (b != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRsaEncryptDecryptTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRsaEncryptDecryptTest.java
@@ -128,8 +128,9 @@ class CryptographicOperationsRsaEncryptDecryptTest extends AbstractCryptographic
         request.setCipherAttributes(buildRsaPkcs1EncryptAttributes());
         request.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
 
+        UUID tokenUuid = tokenInstance.getUuid();
         Assertions.assertThrows(CryptographicOperationException.class,
-                () -> cryptographicOperationsService.encryptData(tokenInstance.getUuid(), privateKeyUuid, request),
+                () -> cryptographicOperationsService.encryptData(tokenUuid, privateKeyUuid, request),
                 "encryptData with a private key should throw CryptographicOperationException");
     }
 
@@ -145,8 +146,9 @@ class CryptographicOperationsRsaEncryptDecryptTest extends AbstractCryptographic
         request.setCipherAttributes(buildRsaPkcs1EncryptAttributes());
         request.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
 
+        UUID tokenUuid = tokenInstance.getUuid();
         Assertions.assertThrows(CryptographicOperationException.class,
-                () -> cryptographicOperationsService.decryptData(tokenInstance.getUuid(), publicKeyUuid, request),
+                () -> cryptographicOperationsService.decryptData(tokenUuid, publicKeyUuid, request),
                 "decryptData with a public key should throw CryptographicOperationException");
     }
 

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRsaEncryptDecryptTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRsaEncryptDecryptTest.java
@@ -1,0 +1,211 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.BooleanAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.RsaEncryptionScheme;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.DecryptDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.EncryptDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.CipherRequestData;
+import com.czertainly.cp.soft.attribute.RsaCipherAttributes;
+import com.czertainly.cp.soft.attribute.RsaKeyAttributes;
+import com.czertainly.cp.soft.exception.CryptographicOperationException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+class CryptographicOperationsRsaEncryptDecryptTest extends AbstractCryptographicOperationsTest {
+
+    private static final byte[] PLAINTEXT = "Hello, CZERTAINLY!".getBytes();
+
+    static Stream<Arguments> parameters() {
+        // RSA-1024 + OAEP + SHA_512 is excluded: OAEP-SHA-512 has a fixed overhead of
+        // 2 * hLen + 2 = 2 * 64 + 2 = 130 bytes, which already exceeds the 128-byte (1024-bit)
+        // RSA block size, leaving no room for any plaintext.
+        // BouncyCastle rejects this at encryption time with "too much data for RSA block".
+        return Stream.of(
+                // PKCS1_v1_5 — no digest, no MGF flag
+                Arguments.of(1024, RsaEncryptionScheme.PKCS1_v1_5, null,                   false),
+                Arguments.of(2048, RsaEncryptionScheme.PKCS1_v1_5, null,                   false),
+                Arguments.of(4096, RsaEncryptionScheme.PKCS1_v1_5, null,                   false),
+                // OAEP — 1024-bit key
+                Arguments.of(1024, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_256, true),
+                Arguments.of(1024, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_256, false),
+                Arguments.of(1024, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_384, true),
+                Arguments.of(1024, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_384, false),
+                // OAEP — 2048-bit key
+                Arguments.of(2048, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_256, true),
+                Arguments.of(2048, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_256, false),
+                Arguments.of(2048, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_384, true),
+                Arguments.of(2048, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_384, false),
+                Arguments.of(2048, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_512, true),
+                Arguments.of(2048, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_512, false),
+                // OAEP — 4096-bit key
+                Arguments.of(4096, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_256, true),
+                Arguments.of(4096, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_256, false),
+                Arguments.of(4096, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_384, true),
+                Arguments.of(4096, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_384, false),
+                Arguments.of(4096, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_512, true),
+                Arguments.of(4096, RsaEncryptionScheme.OAEP,       DigestAlgorithm.SHA_512, false)
+        );
+    }
+
+    @ParameterizedTest(name = "RSA-{0} {1} {2} mgf={3}")
+    @MethodSource("parameters")
+    void testEncryptDecryptRsa(int keySize, RsaEncryptionScheme scheme,
+                               DigestAlgorithm hash, boolean useMgf) throws NotFoundException {
+        // Create key pair
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildRsaCreateKeyAttributes("test-rsa-" + keySize, keySize));
+
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        // Encrypt with public key
+        CipherDataRequestDto encryptRequest = new CipherDataRequestDto();
+        if (scheme == RsaEncryptionScheme.PKCS1_v1_5) {
+            encryptRequest.setCipherAttributes(buildRsaPkcs1EncryptAttributes());
+        } else {
+            encryptRequest.setCipherAttributes(buildRsaOaepEncryptAttributes(hash, useMgf));
+        }
+        encryptRequest.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
+
+        EncryptDataResponseDto encryptResponse = cryptographicOperationsService.encryptData(
+                tokenInstance.getUuid(), publicKeyUuid, encryptRequest);
+
+        Assertions.assertNotNull(encryptResponse.getEncryptedData());
+        Assertions.assertFalse(encryptResponse.getEncryptedData().isEmpty());
+        byte[] encryptedBytes = encryptResponse.getEncryptedData().getFirst().getData();
+        Assertions.assertFalse(java.util.Arrays.equals(encryptedBytes, PLAINTEXT),
+                "Encrypted data should differ from plaintext");
+
+        // Decrypt with private key
+        CipherDataRequestDto decryptRequest = new CipherDataRequestDto();
+        if (scheme == RsaEncryptionScheme.PKCS1_v1_5) {
+            decryptRequest.setCipherAttributes(buildRsaPkcs1EncryptAttributes());
+        } else {
+            decryptRequest.setCipherAttributes(buildRsaOaepEncryptAttributes(hash, useMgf));
+        }
+        decryptRequest.setCipherData(List.of(new CipherRequestData(encryptedBytes, "item-1")));
+
+        DecryptDataResponseDto decryptResponse = cryptographicOperationsService.decryptData(
+                tokenInstance.getUuid(), privateKeyUuid, decryptRequest);
+
+        Assertions.assertNotNull(decryptResponse.getDecryptedData());
+        Assertions.assertFalse(decryptResponse.getDecryptedData().isEmpty());
+        byte[] decryptedBytes = decryptResponse.getDecryptedData().getFirst().getData();
+        Assertions.assertArrayEquals(PLAINTEXT, decryptedBytes,
+                "Decrypted data should match original plaintext");
+    }
+
+    @Test
+    void testEncryptRejectsPrivateKey() throws NotFoundException {
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildRsaCreateKeyAttributes("test-rsa-reject-enc", 2048));
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+
+        CipherDataRequestDto request = new CipherDataRequestDto();
+        request.setCipherAttributes(buildRsaPkcs1EncryptAttributes());
+        request.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
+
+        Assertions.assertThrows(CryptographicOperationException.class,
+                () -> cryptographicOperationsService.encryptData(tokenInstance.getUuid(), privateKeyUuid, request),
+                "encryptData with a private key should throw CryptographicOperationException");
+    }
+
+    @Test
+    void testDecryptRejectsPublicKey() throws NotFoundException {
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildRsaCreateKeyAttributes("test-rsa-reject-dec", 2048));
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        CipherDataRequestDto request = new CipherDataRequestDto();
+        request.setCipherAttributes(buildRsaPkcs1EncryptAttributes());
+        request.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
+
+        Assertions.assertThrows(CryptographicOperationException.class,
+                () -> cryptographicOperationsService.decryptData(tokenInstance.getUuid(), publicKeyUuid, request),
+                "decryptData with a public key should throw CryptographicOperationException");
+    }
+
+    private List<RequestAttribute> buildRsaCreateKeyAttributes(String alias, int keySize) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+        attributes.add(buildAliasAttribute(alias));
+        attributes.add(buildAlgorithmAttribute(KeyAlgorithm.RSA));
+
+        RequestAttributeV2 rsaKeySize = new RequestAttributeV2();
+        rsaKeySize.setName(RsaKeyAttributes.ATTRIBUTE_DATA_RSA_KEY_SIZE);
+        rsaKeySize.setContentType(AttributeContentType.INTEGER);
+        rsaKeySize.setContent(List.of(new IntegerAttributeContentV2("RSA_" + keySize, keySize)));
+        attributes.add(rsaKeySize);
+
+        return attributes;
+    }
+
+    private List<RequestAttribute> buildRsaPkcs1EncryptAttributes() {
+        List<RequestAttribute> attributes = new ArrayList<>();
+
+        RequestAttributeV2 schemeAttr = new RequestAttributeV2();
+        schemeAttr.setName(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME);
+        schemeAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 schemeContent = new StringAttributeContentV2();
+        schemeContent.setReference(RsaEncryptionScheme.PKCS1_v1_5.getCode());
+        schemeContent.setData(RsaEncryptionScheme.PKCS1_v1_5.getCode());
+        schemeAttr.setContent(List.of(schemeContent));
+        attributes.add(schemeAttr);
+
+        return attributes;
+    }
+
+    private List<RequestAttribute> buildRsaOaepEncryptAttributes(DigestAlgorithm hash, boolean useMgf) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+
+        RequestAttributeV2 schemeAttr = new RequestAttributeV2();
+        schemeAttr.setName(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME);
+        schemeAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 schemeContent = new StringAttributeContentV2();
+        schemeContent.setReference(RsaEncryptionScheme.OAEP.getCode());
+        schemeContent.setData(RsaEncryptionScheme.OAEP.getCode());
+        schemeAttr.setContent(List.of(schemeContent));
+        attributes.add(schemeAttr);
+
+        RequestAttributeV2 hashAttr = new RequestAttributeV2();
+        hashAttr.setName(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_OAEP_HASH_NAME);
+        hashAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 hashContent = new StringAttributeContentV2();
+        hashContent.setReference(hash.getCode());
+        hashContent.setData(hash.getCode());
+        hashAttr.setContent(List.of(hashContent));
+        attributes.add(hashAttr);
+
+        RequestAttributeV2 mgfAttr = new RequestAttributeV2();
+        mgfAttr.setName(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_OAEP_USE_MGF_NAME);
+        mgfAttr.setContentType(AttributeContentType.BOOLEAN);
+        mgfAttr.setContent(List.of(new BooleanAttributeContentV2(useMgf)));
+        attributes.add(mgfAttr);
+
+        return attributes;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRsaSignVerifyTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsRsaSignVerifyTest.java
@@ -1,0 +1,142 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.RsaSignatureScheme;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
+import com.czertainly.cp.soft.attribute.RsaKeyAttributes;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+class CryptographicOperationsRsaSignVerifyTest extends AbstractCryptographicOperationsTest {
+
+    static Stream<Arguments> parameters() {
+        // RSA-1024 + PSS + SHA_512 is excluded: PSS with SHA-512 and the default salt length
+        // (sLen = hLen = 64 bytes) requires a modulus of at least
+        // 8 * ceil((hLen + sLen + 2) / 8) = 8 * ceil(130 / 8) = 1040 bits.
+        // A 1024-bit key is too small — BouncyCastle rejects it with
+        // "key too small for specified hash and salt lengths".
+        return Stream.of(
+                Arguments.of(1024, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_256),
+                Arguments.of(1024, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_384),
+                Arguments.of(1024, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_512),
+                Arguments.of(1024, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_256),
+                Arguments.of(1024, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_384),
+                Arguments.of(2048, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_256),
+                Arguments.of(2048, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_384),
+                Arguments.of(2048, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_512),
+                Arguments.of(2048, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_256),
+                Arguments.of(2048, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_384),
+                Arguments.of(2048, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_512),
+                Arguments.of(4096, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_256),
+                Arguments.of(4096, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_384),
+                Arguments.of(4096, RsaSignatureScheme.PKCS1_v1_5, DigestAlgorithm.SHA_512),
+                Arguments.of(4096, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_256),
+                Arguments.of(4096, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_384),
+                Arguments.of(4096, RsaSignatureScheme.PSS,        DigestAlgorithm.SHA_512)
+        );
+    }
+
+    @ParameterizedTest(name = "RSA-{0} {1} {2}")
+    @MethodSource("parameters")
+    void testSignVerifyRsa(int keySize, RsaSignatureScheme scheme, DigestAlgorithm digest)
+            throws NotFoundException {
+        // Create key pair
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(buildRsaCreateKeyAttributes("test-rsa-" + keySize, keySize));
+
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        Assertions.assertEquals(KeyAlgorithm.RSA, keyPair.getPrivateKeyData().getKeyData().getAlgorithm());
+        Assertions.assertEquals(KeyAlgorithm.RSA, keyPair.getPublicKeyData().getKeyData().getAlgorithm());
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        // Sign
+        byte[] plaintext = "Hello, CZERTAINLY!".getBytes();
+        SignDataRequestDto signRequest = new SignDataRequestDto();
+        signRequest.setSignatureAttributes(buildRsaSignatureAttributes(scheme, digest));
+        signRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+
+        SignDataResponseDto signResponse = cryptographicOperationsService.signData(
+                tokenInstance.getUuid(), privateKeyUuid, signRequest);
+
+        Assertions.assertNotNull(signResponse.getSignatures());
+        Assertions.assertEquals(1, signResponse.getSignatures().size());
+        byte[] signatureBytes = signResponse.getSignatures().get(0).getData();
+        Assertions.assertNotNull(signatureBytes);
+        Assertions.assertTrue(signatureBytes.length > 0);
+        Assertions.assertNull(signResponse.getSignatures().get(0).getDetails());
+
+        // Verify
+        VerifyDataRequestDto verifyRequest = new VerifyDataRequestDto();
+        verifyRequest.setSignatureAttributes(buildRsaSignatureAttributes(scheme, digest));
+        verifyRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+        verifyRequest.setSignatures(List.of(new SignatureRequestData(signatureBytes, "item-1")));
+
+        VerifyDataResponseDto verifyResponse = cryptographicOperationsService.verifyData(
+                tokenInstance.getUuid(), publicKeyUuid, verifyRequest);
+
+        Assertions.assertNotNull(verifyResponse.getVerifications());
+        Assertions.assertEquals(1, verifyResponse.getVerifications().size());
+        Assertions.assertTrue(verifyResponse.getVerifications().get(0).isResult());
+    }
+
+    private List<RequestAttribute> buildRsaCreateKeyAttributes(String alias, int keySize) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+        attributes.add(buildAliasAttribute(alias));
+        attributes.add(buildAlgorithmAttribute(KeyAlgorithm.RSA));
+
+        RequestAttributeV2 rsaKeySize = new RequestAttributeV2();
+        rsaKeySize.setName(RsaKeyAttributes.ATTRIBUTE_DATA_RSA_KEY_SIZE);
+        rsaKeySize.setContentType(AttributeContentType.INTEGER);
+        rsaKeySize.setContent(List.of(new IntegerAttributeContentV2("RSA_" + keySize, keySize)));
+        attributes.add(rsaKeySize);
+
+        return attributes;
+    }
+
+    private List<RequestAttribute> buildRsaSignatureAttributes(RsaSignatureScheme scheme, DigestAlgorithm digest) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+
+        RequestAttributeV2 schemeAttr = new RequestAttributeV2();
+        schemeAttr.setName(RsaKeyAttributes.ATTRIBUTE_DATA_RSA_SIG_SCHEME);
+        schemeAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 schemeContent = new StringAttributeContentV2();
+        schemeContent.setReference(scheme.getCode());
+        schemeContent.setData(scheme.getCode());
+        schemeAttr.setContent(List.of(schemeContent));
+        attributes.add(schemeAttr);
+
+        RequestAttributeV2 digestAttr = new RequestAttributeV2();
+        digestAttr.setName(RsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST);
+        digestAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 digestContent = new StringAttributeContentV2();
+        digestContent.setReference(digest.getCode());
+        digestContent.setData(digest.getCode());
+        digestAttr.setContent(List.of(digestContent));
+        attributes.add(digestAttr);
+
+        return attributes;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsSlhdsaSignVerifyTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsSlhdsaSignVerifyTest.java
@@ -1,0 +1,147 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.BooleanAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
+import com.czertainly.cp.soft.attribute.SLHDSAKeyAttributes;
+import com.czertainly.cp.soft.collection.SLHDSAHash;
+import com.czertainly.cp.soft.collection.SLHDSASecurityCategory;
+import com.czertainly.cp.soft.collection.SLHDSASignatureMode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+class CryptographicOperationsSlhdsaSignVerifyTest extends AbstractCryptographicOperationsTest {
+
+    static Stream<Arguments> parameters() {
+        return Stream.of(
+                // prehash = false: all hash/mode combinations across all categories
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_1, SLHDSAHash.SHA2,    SLHDSASignatureMode.FAST,  false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_1, SLHDSAHash.SHA2,    SLHDSASignatureMode.SMALL, false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_1, SLHDSAHash.SHAKE256, SLHDSASignatureMode.FAST,  false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_1, SLHDSAHash.SHAKE256, SLHDSASignatureMode.SMALL, false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_3, SLHDSAHash.SHA2,    SLHDSASignatureMode.FAST,  false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_3, SLHDSAHash.SHA2,    SLHDSASignatureMode.SMALL, false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_3, SLHDSAHash.SHAKE256, SLHDSASignatureMode.FAST,  false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_3, SLHDSAHash.SHAKE256, SLHDSASignatureMode.SMALL, false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_5, SLHDSAHash.SHA2,    SLHDSASignatureMode.FAST,  false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_5, SLHDSAHash.SHA2,    SLHDSASignatureMode.SMALL, false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_5, SLHDSAHash.SHAKE256, SLHDSASignatureMode.FAST,  false),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_5, SLHDSAHash.SHAKE256, SLHDSASignatureMode.SMALL, false),
+                // prehash = true: representative hash/mode per category
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_1, SLHDSAHash.SHA2,    SLHDSASignatureMode.FAST,  true),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_3, SLHDSAHash.SHA2,    SLHDSASignatureMode.FAST,  true),
+                Arguments.of(SLHDSASecurityCategory.CATEGORY_5, SLHDSAHash.SHA2,    SLHDSASignatureMode.FAST,  true)
+        );
+    }
+
+    @ParameterizedTest(name = "{0} {1} {2} prehash={3}")
+    @MethodSource("parameters")
+    void testSignVerifySlhDsa(SLHDSASecurityCategory category, SLHDSAHash hash,
+                              SLHDSASignatureMode mode, boolean prehash) throws NotFoundException {
+        // Create key pair
+        CreateKeyRequestDto createKeyRequestDto = new CreateKeyRequestDto();
+        createKeyRequestDto.setCreateKeyAttributes(
+                buildSlhDsaCreateKeyAttributes("test-slhdsa-" + category.name(), category, hash, mode, prehash));
+
+        KeyPairDataResponseDto keyPair = keyManagementService.createKeyPair(tokenInstance.getUuid(), createKeyRequestDto);
+
+        Assertions.assertEquals(KeyAlgorithm.SLHDSA, keyPair.getPrivateKeyData().getKeyData().getAlgorithm());
+        Assertions.assertEquals(KeyAlgorithm.SLHDSA, keyPair.getPublicKeyData().getKeyData().getAlgorithm());
+
+        UUID privateKeyUuid = UUID.fromString(keyPair.getPrivateKeyData().getUuid());
+        UUID publicKeyUuid = UUID.fromString(keyPair.getPublicKeyData().getUuid());
+
+        // Sign
+        byte[] plaintext = "Hello, CZERTAINLY!".getBytes();
+        SignDataRequestDto signRequest = new SignDataRequestDto();
+        signRequest.setSignatureAttributes(List.of());
+        signRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+
+        SignDataResponseDto signResponse = cryptographicOperationsService.signData(
+                tokenInstance.getUuid(), privateKeyUuid, signRequest);
+
+        Assertions.assertNotNull(signResponse.getSignatures());
+        Assertions.assertEquals(1, signResponse.getSignatures().size());
+        byte[] signatureBytes = signResponse.getSignatures().get(0).getData();
+        Assertions.assertNotNull(signatureBytes);
+        Assertions.assertTrue(signatureBytes.length > 0);
+        Assertions.assertNull(signResponse.getSignatures().get(0).getDetails());
+
+        // Verify
+        VerifyDataRequestDto verifyRequest = new VerifyDataRequestDto();
+        verifyRequest.setSignatureAttributes(List.of());
+        verifyRequest.setData(List.of(new SignatureRequestData(plaintext, "item-1")));
+        verifyRequest.setSignatures(List.of(new SignatureRequestData(signatureBytes, "item-1")));
+
+        VerifyDataResponseDto verifyResponse = cryptographicOperationsService.verifyData(
+                tokenInstance.getUuid(), publicKeyUuid, verifyRequest);
+
+        Assertions.assertNotNull(verifyResponse.getVerifications());
+        Assertions.assertEquals(1, verifyResponse.getVerifications().size());
+        Assertions.assertTrue(verifyResponse.getVerifications().get(0).isResult());
+    }
+
+    private List<RequestAttribute> buildSlhDsaCreateKeyAttributes(
+            String alias,
+            SLHDSASecurityCategory category,
+            SLHDSAHash hash,
+            SLHDSASignatureMode mode,
+            boolean prehash) {
+        List<RequestAttribute> attributes = new ArrayList<>();
+        attributes.add(buildAliasAttribute(alias));
+        attributes.add(buildAlgorithmAttribute(KeyAlgorithm.SLHDSA));
+
+        RequestAttributeV2 categoryAttr = new RequestAttributeV2();
+        categoryAttr.setName(SLHDSAKeyAttributes.ATTRIBUTE_DATA_SLHDSA_SECURITY_CATEGORY);
+        categoryAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 categoryContent = new StringAttributeContentV2();
+        categoryContent.setReference(category.name());
+        categoryContent.setData(category.getNistSecurityCategory());
+        categoryAttr.setContent(List.of(categoryContent));
+        attributes.add(categoryAttr);
+
+        RequestAttributeV2 hashAttr = new RequestAttributeV2();
+        hashAttr.setName(SLHDSAKeyAttributes.ATTRIBUTE_DATA_SLHDSA_HASH);
+        hashAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 hashContent = new StringAttributeContentV2();
+        hashContent.setReference(hash.name());
+        hashContent.setData(hash.getHashName());
+        hashAttr.setContent(List.of(hashContent));
+        attributes.add(hashAttr);
+
+        RequestAttributeV2 modeAttr = new RequestAttributeV2();
+        modeAttr.setName(SLHDSAKeyAttributes.ATTRIBUTE_DATA_SLHDSA_SIGNATURE_MODE);
+        modeAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 modeContent = new StringAttributeContentV2();
+        modeContent.setReference(mode.name());
+        modeContent.setData(mode.name());
+        modeAttr.setContent(List.of(modeContent));
+        attributes.add(modeAttr);
+
+        RequestAttributeV2 prehashAttr = new RequestAttributeV2();
+        prehashAttr.setName(SLHDSAKeyAttributes.ATTRIBUTE_DATA_SLHDSA_PREHASH);
+        prehashAttr.setContentType(AttributeContentType.BOOLEAN);
+        prehashAttr.setContent(List.of(new BooleanAttributeContentV2(prehash)));
+        attributes.add(prehashAttr);
+
+        return attributes;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/util/KeyStoreUtilTest.java
+++ b/src/test/java/com/czertainly/cp/soft/util/KeyStoreUtilTest.java
@@ -91,7 +91,7 @@ class KeyStoreUtilTest {
     // -------------------------------------------------------------------------
 
     @Test
-    void spkiKeyValueFromKeyStoreMatchesGeneratedPublicKey() throws Exception {
+    void spkiKeyValueFromKeyStoreMatchesGeneratedPublicKey() {
         byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
         KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
         BCMLKEMPublicKey publicKey = KeyStoreUtil.generateMLKEMKey(ks, "mlkem", MLKEMSecurityCategory.CATEGORY_3, PASSWORD);
@@ -155,7 +155,7 @@ class KeyStoreUtilTest {
     }
 
     @Test
-    void deleteNonExistentAliasDoesNotThrow() throws Exception {
+    void deleteNonExistentAliasDoesNotThrow() {
         byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
         KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
 

--- a/src/test/java/com/czertainly/cp/soft/util/KeyStoreUtilTest.java
+++ b/src/test/java/com/czertainly/cp/soft/util/KeyStoreUtilTest.java
@@ -1,0 +1,164 @@
+package com.czertainly.cp.soft.util;
+
+import com.czertainly.api.model.connector.cryptography.key.value.SpkiKeyValue;
+import com.czertainly.cp.soft.collection.EcdsaCurveName;
+import com.czertainly.cp.soft.collection.FalconDegree;
+import com.czertainly.cp.soft.collection.MLKEMSecurityCategory;
+import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.security.KeyStore;
+import java.security.Security;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KeyStoreUtilTest {
+
+    private static final String PASSWORD = "test-password";
+
+    @BeforeAll
+    static void registerProviders() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(BouncyCastlePQCProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastlePQCProvider());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // createNewKeystore / loadKeystore / saveKeystore
+    // -------------------------------------------------------------------------
+
+    @Test
+    void createNewKeystoreProducesNonEmptyBytes() {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        assertNotNull(bytes);
+        assertTrue(bytes.length > 0);
+    }
+
+    @Test
+    void loadKeystoreRoundtrip() throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+        assertNotNull(ks);
+        assertEquals(0, ks.size());
+    }
+
+    @Test
+    void saveAndLoadKeystorePreservesEntries() throws Exception {
+        byte[] initial = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(initial, PASSWORD);
+        KeyStoreUtil.generateEcdsaKey(ks, "ec-key", EcdsaCurveName.secp256r1, PASSWORD);
+
+        byte[] saved = KeyStoreUtil.saveKeystore(ks, PASSWORD);
+        KeyStore loaded = KeyStoreUtil.loadKeystore(saved, PASSWORD);
+
+        assertTrue(loaded.containsAlias("ec-key"));
+        assertNotNull(loaded.getCertificate("ec-key"));
+    }
+
+    // -------------------------------------------------------------------------
+    // generateMLKEMKey
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @EnumSource(MLKEMSecurityCategory.class)
+    void generateMlkemKeyReturnsPublicKeyWithCertificate(MLKEMSecurityCategory category) throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+
+        BCMLKEMPublicKey publicKey = KeyStoreUtil.generateMLKEMKey(ks, "mlkem", category, PASSWORD);
+
+        assertNotNull(publicKey);
+        assertTrue(publicKey.getAlgorithm().startsWith("ML-KEM"));
+        assertTrue(ks.containsAlias("mlkem"));
+        // New 1.4.0 format: every ML-KEM entry must have an orphan certificate.
+        assertNotNull(ks.getCertificate("mlkem"),
+                "ML-KEM entry must be stored with an orphan certificate in the new format");
+        assertArrayEquals(publicKey.getEncoded(), ks.getCertificate("mlkem").getPublicKey().getEncoded(),
+                "Certificate must embed the same public key that was generated");
+    }
+
+    // -------------------------------------------------------------------------
+    // spkiKeyValueFromKeyStore
+    // -------------------------------------------------------------------------
+
+    @Test
+    void spkiKeyValueFromKeyStoreMatchesGeneratedPublicKey() throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+        BCMLKEMPublicKey publicKey = KeyStoreUtil.generateMLKEMKey(ks, "mlkem", MLKEMSecurityCategory.CATEGORY_3, PASSWORD);
+
+        SpkiKeyValue spki = KeyStoreUtil.spkiKeyValueFromKeyStore(ks, "mlkem");
+
+        assertNotNull(spki);
+        assertNotNull(spki.getValue());
+        byte[] decodedSpki = Base64.getDecoder().decode(spki.getValue());
+        assertArrayEquals(publicKey.getEncoded(), decodedSpki,
+                "SPKI value must match the encoded form of the generated public key");
+    }
+
+    // -------------------------------------------------------------------------
+    // generateEcdsaKey
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @EnumSource(value = EcdsaCurveName.class, names = {"secp256r1", "secp384r1", "secp521r1"})
+    void generateEcdsaKeyStoresEntryWithCertificate(EcdsaCurveName curve) throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+
+        KeyStoreUtil.generateEcdsaKey(ks, "ec-key", curve, PASSWORD);
+
+        assertTrue(ks.containsAlias("ec-key"));
+        assertNotNull(ks.getCertificate("ec-key"));
+        assertNotNull(ks.getKey("ec-key", PASSWORD.toCharArray()));
+    }
+
+    // -------------------------------------------------------------------------
+    // generateFalconKey
+    // -------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @EnumSource(FalconDegree.class)
+    void generateFalconKeyStoresEntryWithCertificate(FalconDegree degree) throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+
+        KeyStoreUtil.generateFalconKey(ks, "falcon-key", degree, PASSWORD);
+
+        assertTrue(ks.containsAlias("falcon-key"));
+        assertNotNull(ks.getCertificate("falcon-key"));
+    }
+
+    // -------------------------------------------------------------------------
+    // deleteAliasFromKeyStore
+    // -------------------------------------------------------------------------
+
+    @Test
+    void deleteAliasRemovesEntry() throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+        KeyStoreUtil.generateEcdsaKey(ks, "ec-key", EcdsaCurveName.secp256r1, PASSWORD);
+        assertTrue(ks.containsAlias("ec-key"));
+
+        KeyStoreUtil.deleteAliasFromKeyStore(ks, "ec-key");
+
+        assertFalse(ks.containsAlias("ec-key"));
+    }
+
+    @Test
+    void deleteNonExistentAliasDoesNotThrow() throws Exception {
+        byte[] bytes = KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD);
+        KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
+
+        assertDoesNotThrow(() -> KeyStoreUtil.deleteAliasFromKeyStore(ks, "non-existent"));
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/util/X509UtilTest.java
+++ b/src/test/java/com/czertainly/cp/soft/util/X509UtilTest.java
@@ -1,0 +1,127 @@
+package com.czertainly.cp.soft.util;
+
+import com.czertainly.cp.soft.collection.FalconDegree;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
+import org.bouncycastle.pqc.jcajce.spec.FalconParameterSpec;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.*;
+import java.security.cert.X509Certificate;
+import java.security.spec.ECGenParameterSpec;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class X509UtilTest {
+
+    @BeforeAll
+    static void registerProviders() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(BouncyCastlePQCProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastlePQCProvider());
+        }
+    }
+
+    @Test
+    void generateRsaOrphanCertificateEmbedPublicKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(2048);
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = X509Util.generateRsaOrphanX509Certificate(kp);
+
+        assertNotNull(cert);
+        assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded());
+        assertDoesNotThrow(() -> cert.checkValidity());
+    }
+
+    @Test
+    void generateEcdsaOrphanCertificateEmbedPublicKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ECDSA", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(new ECGenParameterSpec("P-256"));
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = X509Util.generateEcdsaOrphanX509Certificate(kp);
+
+        assertNotNull(cert);
+        assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded());
+        assertDoesNotThrow(() -> cert.checkValidity());
+    }
+
+    @Test
+    void generateFalcon512OrphanCertificateEmbedPublicKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("Falcon", BouncyCastlePQCProvider.PROVIDER_NAME);
+        kpg.initialize(FalconParameterSpec.falcon_512);
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = X509Util.generateFalconOrphanX509Certificate(kp, FalconDegree.FALCON_512);
+
+        assertNotNull(cert);
+        assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded());
+    }
+
+    @Test
+    void generateFalcon1024OrphanCertificateEmbedPublicKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("Falcon", BouncyCastlePQCProvider.PROVIDER_NAME);
+        kpg.initialize(FalconParameterSpec.falcon_1024);
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = X509Util.generateFalconOrphanX509Certificate(kp, FalconDegree.FALCON_1024);
+
+        assertNotNull(cert);
+        assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded());
+    }
+
+    @Test
+    void generateMlkemOrphanCertificateEmbedsMlkemPublicKey() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(MLKEMParameterSpec.fromName("ML-KEM-768"));
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = X509Util.generateMLKEMOrphanX509Certificate(kp);
+
+        assertNotNull(cert);
+        assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded(),
+                "Certificate SubjectPublicKeyInfo must embed the ML-KEM public key");
+        assertDoesNotThrow(() -> cert.checkValidity());
+        // Signed by an ephemeral EC key — the cert cannot self-verify against the ML-KEM public key.
+        assertTrue(cert.getSigAlgName().toUpperCase().contains("ECDSA"),
+                "ML-KEM orphan cert must be signed with ECDSA (not ML-KEM itself)");
+    }
+
+    @Test
+    void generateMlkemOrphanCertificateForAllParameterSets() throws Exception {
+        for (String paramSet : new String[]{"ML-KEM-512", "ML-KEM-768", "ML-KEM-1024"}) {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", BouncyCastleProvider.PROVIDER_NAME);
+            kpg.initialize(MLKEMParameterSpec.fromName(paramSet));
+            KeyPair kp = kpg.generateKeyPair();
+
+            X509Certificate cert = X509Util.generateMLKEMOrphanX509Certificate(kp);
+
+            assertNotNull(cert, "Certificate must be generated for " + paramSet);
+            assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded(),
+                    "Public key mismatch for " + paramSet);
+        }
+    }
+
+    @Test
+    void generateOrphanCertificateHas30YearValidity() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ECDSA", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(new ECGenParameterSpec("P-256"));
+        KeyPair kp = kpg.generateKeyPair();
+
+        X509Certificate cert = X509Util.generateEcdsaOrphanX509Certificate(kp);
+
+        long now = System.currentTimeMillis();
+        long remainingMs = cert.getNotAfter().getTime() - now;
+        long thirtyYearsMs = 86400_000L * 365 * 30;
+        // notBefore is 1 year in the past (clock-skew tolerance); measure from now to notAfter.
+        // Allow ±2 days for rounding/leap years.
+        assertTrue(Math.abs(remainingMs - thirtyYearsMs) < 86400_000L * 2,
+                "Certificate validity must be approximately 30 years from now");
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/util/X509UtilTest.java
+++ b/src/test/java/com/czertainly/cp/soft/util/X509UtilTest.java
@@ -7,6 +7,7 @@ import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
 import org.bouncycastle.pqc.jcajce.spec.FalconParameterSpec;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.security.*;
 import java.security.cert.X509Certificate;
@@ -36,7 +37,7 @@ class X509UtilTest {
 
         assertNotNull(cert);
         assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded());
-        assertDoesNotThrow(() -> cert.checkValidity());
+        assertDoesNotThrow((Executable) cert::checkValidity);
     }
 
     @Test
@@ -49,7 +50,7 @@ class X509UtilTest {
 
         assertNotNull(cert);
         assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded());
-        assertDoesNotThrow(() -> cert.checkValidity());
+        assertDoesNotThrow((Executable) cert::checkValidity);
     }
 
     @Test
@@ -87,7 +88,7 @@ class X509UtilTest {
         assertNotNull(cert);
         assertArrayEquals(kp.getPublic().getEncoded(), cert.getPublicKey().getEncoded(),
                 "Certificate SubjectPublicKeyInfo must embed the ML-KEM public key");
-        assertDoesNotThrow(() -> cert.checkValidity());
+        assertDoesNotThrow((Executable) cert::checkValidity);
         // Signed by an ephemeral EC key — the cert cannot self-verify against the ML-KEM public key.
         assertTrue(cert.getSigAlgName().toUpperCase().contains("ECDSA"),
                 "ML-KEM orphan cert must be signed with ECDSA (not ML-KEM itself)");

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatIT.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatIT.java
@@ -1,0 +1,406 @@
+package db.migration;
+
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyFormat;
+import com.czertainly.api.model.common.enums.cryptography.KeyType;
+import com.czertainly.cp.soft.Application;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import com.czertainly.cp.soft.util.SecretEncodingVersion;
+import com.czertainly.cp.soft.util.SecretsUtil;
+import com.czertainly.cp.soft.util.X509Util;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERBMPString;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.pkcs.PKCS12PfxPdu;
+import org.bouncycastle.pkcs.PKCS12PfxPduBuilder;
+import org.bouncycastle.pkcs.PKCS12SafeBagBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCS12MacCalculatorBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.migration.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Spring Boot integration test for {@link V202604211200__MigrateMLKEMKeyStorageFormat}.
+ *
+ * <p>The test seeds the in-memory HSQL database with a {@code token_instance} row that contains a
+ * legacy ML-KEM keystore (private key stored as raw PKCS8 bytes, no certificate chain) and a
+ * corresponding {@code key_data} row that holds the public key in SPKI format — exactly the state
+ * that would be present after upgrading from 1.3.1 to 1.4.0 without running any migration.
+ *
+ * <p>After running the migration, it asserts that:
+ * <ul>
+ *   <li>The keystore blob in {@code token_instance.data} now contains an orphan certificate for every ML-KEM alias.</li>
+ *   <li>The private key is still recoverable and its bytes are unchanged.</li>
+ *   <li>Non-ML-KEM entries in the same keystore are untouched.</li>
+ *   <li>Token instances that already use the new format are not re-written.</li>
+ * </ul>
+ */
+@SpringBootTest(classes = Application.class)
+class V202604211200__MigrateMLKEMKeyStorageFormatIT {
+
+    private static final String PASSWORD = "integration-test-password";
+    private static final String MLKEM_ALIAS = "my-mlkem-key";
+    private static final String ECDSA_ALIAS = "my-ecdsa-key";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired
+    private DataSource dataSource;
+
+    /**
+     * UUIDs of rows created during a test — cleaned up in @AfterEach.
+     */
+    private final Map<UUID, UUID> createdTokens = new HashMap<>();  // tokenUuid → tokenUuid
+
+    @BeforeAll
+    static void ensureBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        if (createdTokens.isEmpty()) return;
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            for (UUID tokenUuid : createdTokens.keySet()) {
+                try (PreparedStatement ps = conn.prepareStatement("DELETE FROM key_data WHERE token_instance_uuid = ?")) {
+                    ps.setObject(1, tokenUuid);
+                    ps.executeUpdate();
+                }
+                try (PreparedStatement ps = conn.prepareStatement("DELETE FROM token_instance WHERE uuid = ?")) {
+                    ps.setObject(1, tokenUuid);
+                    ps.executeUpdate();
+                }
+            }
+        }
+        createdTokens.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void migrationConvertsLegacyMlkemEntry() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            // Seed the database with a legacy token instance.
+            UUID tokenUuid = UUID.randomUUID();
+            byte[] legacyKeystore = buildLegacyKeystore(mlkemPair, PASSWORD);
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, legacyKeystore);
+
+            // Seed the key_data row (public key in SPKI format, as written by KeyManagementServiceImpl).
+            UUID keyDataUuid = UUID.randomUUID();
+            insertMlkemPublicKeyData(conn, keyDataUuid, tokenUuid, MLKEM_ALIAS, mlkemPair.getPublic());
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            // Run the migration.
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            // Load the updated keystore from the database.
+            KeyStore migratedKs = loadUpdatedKeystore(conn, tokenUuid, PASSWORD);
+
+            // The ML-KEM alias must now have a certificate.
+            Certificate cert = migratedKs.getCertificate(MLKEM_ALIAS);
+            assertNotNull(cert, "ML-KEM alias must have an orphan certificate after migration");
+
+            // The certificate's public key must match the original.
+            assertArrayEquals(mlkemPair.getPublic().getEncoded(), cert.getPublicKey().getEncoded(),
+                    "Certificate public key must match the original ML-KEM public key");
+
+            // The private key must still be recoverable.
+            Key recoveredKey = migratedKs.getKey(MLKEM_ALIAS, PASSWORD.toCharArray());
+            assertNotNull(recoveredKey, "Private key must still be recoverable after migration");
+            assertArrayEquals(mlkemPair.getPrivate().getEncoded(), recoveredKey.getEncoded(),
+                    "Private key bytes must be unchanged after migration");
+        }
+    }
+
+    @Test
+    void migrationLeavesNewFormatUnchanged() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            byte[] newFormatKeystore = buildNewFormatKeystore(mlkemPair, PASSWORD);
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, newFormatKeystore);
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            // Record the data blob before the migration.
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            // The data blob must not have changed (migration must not re-write already-new keystores).
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "A keystore already in the new format must not be rewritten by the migration");
+        }
+    }
+
+    @Test
+    void migrationPreservesNonMlkemEntriesAlongsideMigratedMlkemEntry() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        // Build a PKCS12 that holds BOTH a legacy ML-KEM entry AND a normal ECDSA entry using the
+        // low-level builder (BC 1.73+ no longer supports setKeyEntry(alias, byte[], null)).
+        KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        ecKpg.initialize(new java.security.spec.ECGenParameterSpec("P-256"));
+        KeyPair ecPair = ecKpg.generateKeyPair();
+        X509Certificate ecCert = X509Util.generateEcdsaOrphanX509Certificate(ecPair);
+
+        byte[] keystoreBytes = buildMixedPkcs12(MLKEM_ALIAS, mlkemPair.getPrivate(), ECDSA_ALIAS,
+                ecPair.getPrivate(), ecCert, PASSWORD.toCharArray());
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, keystoreBytes);
+            insertMlkemPublicKeyData(conn, UUID.randomUUID(), tokenUuid, MLKEM_ALIAS, mlkemPair.getPublic());
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            KeyStore migratedKs = loadUpdatedKeystore(conn, tokenUuid, PASSWORD);
+
+            // ML-KEM must now have a cert.
+            assertNotNull(migratedKs.getCertificate(MLKEM_ALIAS), "ML-KEM alias must have a cert after migration");
+
+            // ECDSA entry must still be present and functional.
+            assertNotNull(migratedKs.getCertificate(ECDSA_ALIAS), "ECDSA alias must still have its cert");
+            Key ecKey = migratedKs.getKey(ECDSA_ALIAS, PASSWORD.toCharArray());
+            assertNotNull(ecKey, "ECDSA private key must still be recoverable");
+            assertArrayEquals(ecPair.getPrivate().getEncoded(), ecKey.getEncoded(),
+                    "ECDSA private key bytes must be unchanged");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — keystore construction
+    // -------------------------------------------------------------------------
+
+    private static KeyPair generateMlkemKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(MLKEMParameterSpec.fromName("ML-KEM-768"));
+        return kpg.generateKeyPair();
+    }
+
+    /**
+     * Builds a PKCS12 keystore in the <em>old</em> (1.3.1) format: bare PKCS8ShroudedKeyBag, no cert.
+     *
+     * <p>BouncyCastle 1.73+ no longer supports {@code setKeyEntry(alias, byte[], null)} on PKCS12;
+     * this method uses the low-level {@link PKCS12PfxPduBuilder} instead.
+     */
+    private static byte[] buildLegacyKeystore(KeyPair mlkemPair, String password) throws Exception {
+        return buildBareKeyPkcs12(MLKEM_ALIAS, mlkemPair.getPrivate(), password.toCharArray());
+    }
+
+    /**
+     * Builds a PKCS12 keystore in the <em>new</em> (1.4.0) format: PrivateKeyEntry + orphan cert.
+     */
+    private static byte[] buildNewFormatKeystore(KeyPair mlkemPair, String password) throws Exception {
+        KeyStore ks = KeyStore.getInstance("PKCS12", BouncyCastleProvider.PROVIDER_NAME);
+        ks.load(null, password.toCharArray());
+        X509Certificate cert = X509Util.generateMLKEMOrphanX509Certificate(mlkemPair);
+        ks.setKeyEntry(MLKEM_ALIAS, mlkemPair.getPrivate(), password.toCharArray(), new Certificate[]{cert});
+        return KeyStoreUtil.saveKeystore(ks, password);
+    }
+
+    /**
+     * Builds a PKCS12 containing a single encrypted key bag for the given private key with no
+     * associated certificate bag — i.e. the legacy 1.3.1 storage format.
+     */
+    private static byte[] buildBareKeyPkcs12(String alias, PrivateKey privateKey, char[] password)
+            throws Exception {
+        PrivateKeyInfo pkInfo = PrivateKeyInfo.getInstance(privateKey.getEncoded());
+        OutputEncryptor keyEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd3_KeyTripleDES_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+
+        byte[] localKeyId = new byte[20];
+        new SecureRandom().nextBytes(localKeyId);
+
+        PKCS12SafeBagBuilder keyBagBuilder = new PKCS12SafeBagBuilder(pkInfo, keyEncryptor);
+        keyBagBuilder.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(alias));
+        keyBagBuilder.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(localKeyId));
+
+        PKCS12PfxPduBuilder pfxBuilder = new PKCS12PfxPduBuilder();
+        pfxBuilder.addData(keyBagBuilder.build());
+
+        PKCS12PfxPdu pfx = pfxBuilder.build(
+                new JcePKCS12MacCalculatorBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME),
+                password);
+
+        return pfx.getEncoded("DER");
+    }
+
+    /**
+     * Builds a PKCS12 containing:
+     * <ul>
+     *   <li>A bare (cert-less) key bag for {@code legacyAlias/legacyKey} — legacy format.</li>
+     *   <li>A key bag and certificate bag linked by {@code LocalKeyId} for
+     *       {@code newAlias/newKey/newCert} — new format.</li>
+     * </ul>
+     */
+    private static byte[] buildMixedPkcs12(String legacyAlias, PrivateKey legacyKey, String newAlias,
+                                           PrivateKey newKey, X509Certificate newCert, char[] password)
+            throws Exception {
+        OutputEncryptor keyEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd3_KeyTripleDES_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+        OutputEncryptor certEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd128BitRC2_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+
+        // Legacy key bag (no cert)
+        byte[] legacyLocalKeyId = new byte[20];
+        new SecureRandom().nextBytes(legacyLocalKeyId);
+        PrivateKeyInfo legacyPkInfo = PrivateKeyInfo.getInstance(legacyKey.getEncoded());
+        PKCS12SafeBagBuilder legacyKeyBag = new PKCS12SafeBagBuilder(legacyPkInfo, keyEncryptor);
+        legacyKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(legacyAlias));
+        legacyKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(legacyLocalKeyId));
+
+        // New-format key + cert linked by a shared localKeyId
+        byte[] newLocalKeyId = new byte[20];
+        new SecureRandom().nextBytes(newLocalKeyId);
+        PrivateKeyInfo newPkInfo = PrivateKeyInfo.getInstance(newKey.getEncoded());
+        PKCS12SafeBagBuilder newKeyBag = new PKCS12SafeBagBuilder(newPkInfo, keyEncryptor);
+        newKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(newAlias));
+        newKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(newLocalKeyId));
+
+        PKCS12SafeBagBuilder newCertBag = new PKCS12SafeBagBuilder(new JcaX509CertificateHolder(newCert));
+        newCertBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(newAlias));
+        newCertBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(newLocalKeyId));
+
+        PKCS12PfxPduBuilder pfxBuilder = new PKCS12PfxPduBuilder();
+        pfxBuilder.addData(legacyKeyBag.build());
+        pfxBuilder.addData(newKeyBag.build());
+        pfxBuilder.addEncryptedData(certEncryptor, newCertBag.build());
+
+        PKCS12PfxPdu pfx = pfxBuilder.build(new JcePKCS12MacCalculatorBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME), password);
+
+        return pfx.getEncoded("DER");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — JDBC data setup / query
+    // -------------------------------------------------------------------------
+
+    private static void insertTokenInstance(Connection conn, UUID tokenUuid,
+                                            String encryptedCode, byte[] keystoreBytes)
+            throws Exception {
+        String data = Base64.getEncoder().encodeToString(keystoreBytes);
+        String sql = "INSERT INTO token_instance (uuid, name, code, data, timestamp) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setObject(1, tokenUuid);
+            ps.setString(2, "migration-test-token-" + tokenUuid);
+            ps.setString(3, encryptedCode);
+            ps.setString(4, data);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void insertMlkemPublicKeyData(Connection conn, UUID keyDataUuid, UUID tokenInstanceUuid,
+                                                 String alias, PublicKey publicKey) throws Exception {
+        // Match the JSON structure produced by RawKeyValue / SpkiKeyValue serialization:
+        // {"value": "<base64-encoded SPKI bytes>"}
+        String base64Spki = Base64.getEncoder().encodeToString(publicKey.getEncoded());
+        Map<String, String> valueMap = new HashMap<>();
+        valueMap.put("value", base64Spki);
+        String valueJson = MAPPER.writeValueAsString(valueMap);
+
+        String sql = "INSERT INTO key_data "
+                + "(uuid, name, algorithm, type, format, value, length, token_instance_uuid) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setObject(1, keyDataUuid);
+            ps.setString(2, alias);
+            ps.setString(3, KeyAlgorithm.MLKEM.name());
+            ps.setString(4, KeyType.PUBLIC_KEY.name());
+            ps.setString(5, KeyFormat.SPKI.name());
+            ps.setString(6, valueJson);
+            ps.setInt(7, 768); // NIST security category level used as a proxy for key length
+            ps.setObject(8, tokenInstanceUuid);
+            ps.executeUpdate();
+        }
+    }
+
+    private static String queryKeystoreData(Connection conn, UUID tokenUuid) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT data FROM token_instance WHERE uuid = ?")) {
+            ps.setObject(1, tokenUuid);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next(), "token_instance row must exist");
+                return rs.getString("data");
+            }
+        }
+    }
+
+    private static KeyStore loadUpdatedKeystore(Connection conn, UUID tokenUuid, String password) throws Exception {
+        String data = queryKeystoreData(conn, tokenUuid);
+        byte[] keystoreBytes = Base64.getDecoder().decode(data);
+        return KeyStoreUtil.loadKeystore(keystoreBytes, password);
+    }
+
+    // -------------------------------------------------------------------------
+    // Minimal Flyway Context adapter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimal implementation of {@link Context} that wraps an existing JDBC {@link Connection}.
+     * Flyway's {@link org.flywaydb.core.api.migration.BaseJavaMigration#migrate} only uses
+     * {@link Context#getConnection()}, so a stub for {@link Context#getConfiguration()} suffices.
+     */
+    private record JdbcMigrationContext(Connection connection) implements Context {
+        @Override
+        public Configuration getConfiguration() {
+            return null; // not used by this migration
+        }
+
+        @Override
+        public Connection getConnection() {
+            return connection;
+        }
+    }
+}

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
@@ -455,8 +455,6 @@ class V202604211200__MigrateMLKEMKeyStorageFormatITest {
 
     private static void insertMlkemPublicKeyData(Connection conn, UUID keyDataUuid, UUID tokenInstanceUuid,
                                                  String alias, PublicKey publicKey) throws Exception {
-        // Match the JSON structure produced by RawKeyValue / SpkiKeyValue serialization:
-        // {"value": "<base64-encoded SPKI bytes>"}
         String base64Spki = Base64.getEncoder().encodeToString(publicKey.getEncoded());
         Map<String, String> valueMap = new HashMap<>();
         valueMap.put("value", base64Spki);

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
@@ -213,6 +213,118 @@ class V202604211200__MigrateMLKEMKeyStorageFormatITest {
         }
     }
 
+    @Test
+    void migrationSkipsTokenWithInvalidPasswordFormat() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            // Not a valid V1 encoded secret — migration must skip this token gracefully.
+            String invalidCode = "this-is-not-a-valid-encrypted-password";
+            byte[] someKeystore = KeyStoreUtil.createNewKeystore("PKCS12", "anypassword");
+            insertTokenInstance(conn, tokenUuid, invalidCode, someKeystore);
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "Token with undecodable password must be skipped without modifying keystore data");
+        }
+    }
+
+    @Test
+    void migrationSkipsTokenWithCorruptedKeystoreBytes() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            // Bytes that decode correctly from base64 but are not a PKCS12 keystore.
+            byte[] garbage = "not-a-pkcs12-keystore".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, garbage);
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "Token with corrupted keystore bytes must be skipped without modifying keystore data");
+        }
+    }
+
+    @Test
+    void migrationSkipsMlkemAliasWhenPublicKeyMissingFromDb() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+        byte[] legacyKeystore = buildLegacyKeystore(mlkemPair, PASSWORD);
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, legacyKeystore);
+            // Intentionally no key_data row → public key cannot be reconstructed.
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "ML-KEM alias without a corresponding public key in key_data must be skipped");
+        }
+    }
+
+    @Test
+    void migrationSkipsMlkemAliasWhenPublicKeyJsonLacksValueField() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+        byte[] legacyKeystore = buildLegacyKeystore(mlkemPair, PASSWORD);
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, legacyKeystore);
+
+            // key_data row is present but the JSON does not contain the expected 'value' field.
+            UUID keyDataUuid = UUID.randomUUID();
+            String sql = "INSERT INTO key_data "
+                    + "(uuid, name, algorithm, type, format, value, length, token_instance_uuid) "
+                    + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+            try (PreparedStatement ps = conn.prepareStatement(sql)) {
+                ps.setObject(1, keyDataUuid);
+                ps.setString(2, MLKEM_ALIAS);
+                ps.setString(3, KeyAlgorithm.MLKEM.name());
+                ps.setString(4, KeyType.PUBLIC_KEY.name());
+                ps.setString(5, KeyFormat.SPKI.name());
+                ps.setString(6, "{\"other\":\"no-value-field-here\"}");
+                ps.setInt(7, 768);
+                ps.setObject(8, tokenUuid);
+                ps.executeUpdate();
+            }
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "ML-KEM alias whose key_data JSON is missing the 'value' field must be skipped");
+        }
+    }
+
     // -------------------------------------------------------------------------
     // Helpers — keystore construction
     // -------------------------------------------------------------------------

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * </ul>
  */
 @SpringBootTest(classes = Application.class)
-class V202604211200__MigrateMLKEMKeyStorageFormatIT {
+class V202604211200__MigrateMLKEMKeyStorageFormatITest {
 
     private static final String PASSWORD = "integration-test-password";
     private static final String MLKEM_ALIAS = "my-mlkem-key";

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatITest.java
@@ -285,6 +285,51 @@ class V202604211200__MigrateMLKEMKeyStorageFormatITest {
     }
 
     @Test
+    void migrationSkipsDeactivatedTokenThatHasMlkemKeys() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            // code = null → deactivated token; migration must detect ML-KEM keys and log a warning but not modify data.
+            insertTokenInstance(conn, tokenUuid, null, KeyStoreUtil.createNewKeystore("PKCS12", "any"));
+            insertMlkemPublicKeyData(conn, UUID.randomUUID(), tokenUuid, MLKEM_ALIAS, mlkemPair.getPublic());
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "Deactivated token (null code) with ML-KEM keys must be skipped without modifying keystore data");
+        }
+    }
+
+    @Test
+    void migrationSkipsDeactivatedTokenWithoutMlkemKeys() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            // code = null → deactivated token with no ML-KEM keys; must be skipped silently.
+            insertTokenInstance(conn, tokenUuid, null, KeyStoreUtil.createNewKeystore("PKCS12", "any"));
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "Deactivated token (null code) without ML-KEM keys must be skipped without modifying keystore data");
+        }
+    }
+
+    @Test
     void migrationSkipsMlkemAliasWhenPublicKeyJsonLacksValueField() throws Exception {
         KeyPair mlkemPair = generateMlkemKeyPair();
         byte[] legacyKeystore = buildLegacyKeystore(mlkemPair, PASSWORD);

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatTest.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatTest.java
@@ -1,0 +1,305 @@
+package db.migration;
+
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import com.czertainly.cp.soft.util.X509Util;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERBMPString;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.pkcs.PKCS12PfxPdu;
+import org.bouncycastle.pkcs.PKCS12PfxPduBuilder;
+import org.bouncycastle.pkcs.PKCS12SafeBagBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCS12MacCalculatorBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Enumeration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the ML-KEM keystore-format migration logic.
+ *
+ * <p>These tests work directly with {@link KeyStore} / {@link KeyStoreUtil} and do not require a
+ * Spring context or a database. They verify:
+ * <ol>
+ *   <li>That a keystore carrying an old-format ML-KEM entry (bare PKCS8 key bag, no certificate)
+ *       is correctly identified and migrated to the new format (PrivateKeyEntry + orphan cert).</li>
+ *   <li>That a keystore that already uses the new format is left untouched.</li>
+ *   <li>That the migration does not touch non-ML-KEM entries stored without a certificate.</li>
+ * </ol>
+ */
+class V202604211200__MigrateMLKEMKeyStorageFormatTest {
+
+    private static final String PASSWORD = "test-password";
+    private static final String ALIAS = "mlkem-key";
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Generates an ML-KEM-768 key pair using BouncyCastle.
+     */
+    private static KeyPair generateMlkemKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(MLKEMParameterSpec.fromName("ML-KEM-768"));
+        return kpg.generateKeyPair();
+    }
+
+    /**
+     * Creates a PKCS12 keystore that stores an ML-KEM private key in the <em>old</em> (1.3.1)
+     * format: a bare PKCS8ShroudedKeyBag with no certificate chain.
+     *
+     * <p>BouncyCastle 1.73+ no longer supports {@code setKeyEntry(alias, byte[], null)} on a PKCS12
+     * keystore; we use the low-level {@link PKCS12PfxPduBuilder} to construct the binary directly
+     * and then load it back through BC's standard {@link KeyStoreUtil#loadKeystore}.
+     */
+    private static byte[] buildLegacyKeystore(KeyPair mlkemPair) throws Exception {
+        return buildBareKeyPkcs12(ALIAS, mlkemPair.getPrivate(), PASSWORD.toCharArray());
+    }
+
+    /**
+     * Creates a PKCS12 keystore that stores an ML-KEM private key in the <em>new</em> (1.4.0)
+     * format: {@code setKeyEntry(alias, PrivateKey, password, chain)}.
+     */
+    private static byte[] buildNewFormatKeystore(KeyPair mlkemPair) throws Exception {
+        KeyStore ks = KeyStore.getInstance("PKCS12", BouncyCastleProvider.PROVIDER_NAME);
+        ks.load(null, PASSWORD.toCharArray());
+        X509Certificate cert = X509Util.generateMLKEMOrphanX509Certificate(mlkemPair);
+        ks.setKeyEntry(ALIAS, mlkemPair.getPrivate(), PASSWORD.toCharArray(), new Certificate[]{cert});
+        return KeyStoreUtil.saveKeystore(ks, PASSWORD);
+    }
+
+    /**
+     * Builds a PKCS12 containing a single encrypted key bag for the given private key with no
+     * associated certificate bag — i.e. the legacy 1.3.1 storage format.
+     */
+    private static byte[] buildBareKeyPkcs12(String alias, PrivateKey privateKey, char[] password)
+            throws Exception {
+        PrivateKeyInfo pkInfo = PrivateKeyInfo.getInstance(privateKey.getEncoded());
+        OutputEncryptor keyEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd3_KeyTripleDES_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+
+        byte[] localKeyId = new byte[20];
+        new SecureRandom().nextBytes(localKeyId);
+
+        PKCS12SafeBagBuilder keyBagBuilder = new PKCS12SafeBagBuilder(pkInfo, keyEncryptor);
+        keyBagBuilder.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(alias));
+        keyBagBuilder.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(localKeyId));
+
+        PKCS12PfxPduBuilder pfxBuilder = new PKCS12PfxPduBuilder();
+        pfxBuilder.addData(keyBagBuilder.build());
+
+        PKCS12PfxPdu pfx = pfxBuilder.build(
+                new JcePKCS12MacCalculatorBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME),
+                password);
+
+        return pfx.getEncoded("DER");
+    }
+
+    /**
+     * Builds a PKCS12 containing:
+     * <ul>
+     *   <li>A bare (cert-less) key bag for {@code legacyAlias/legacyKey} — legacy format.</li>
+     *   <li>A key bag and certificate bag linked by {@code LocalKeyId} for
+     *       {@code newAlias/newKey/newCert} — new format.</li>
+     * </ul>
+     */
+    private static byte[] buildMixedPkcs12(String legacyAlias, PrivateKey legacyKey, String newAlias, PrivateKey newKey,
+                                           X509Certificate newCert) throws Exception {
+        char[] password = PASSWORD.toCharArray();
+
+        OutputEncryptor keyEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd3_KeyTripleDES_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+        OutputEncryptor certEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd128BitRC2_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+
+        // Legacy key bag (no cert)
+        byte[] legacyLocalKeyId = new byte[20];
+        new SecureRandom().nextBytes(legacyLocalKeyId);
+        PrivateKeyInfo legacyPkInfo = PrivateKeyInfo.getInstance(legacyKey.getEncoded());
+        PKCS12SafeBagBuilder legacyKeyBag = new PKCS12SafeBagBuilder(legacyPkInfo, keyEncryptor);
+        legacyKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(legacyAlias));
+        legacyKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(legacyLocalKeyId));
+
+        // New-format key + cert linked by a shared localKeyId
+        byte[] newLocalKeyId = new byte[20];
+        new SecureRandom().nextBytes(newLocalKeyId);
+        PrivateKeyInfo newPkInfo = PrivateKeyInfo.getInstance(newKey.getEncoded());
+        PKCS12SafeBagBuilder newKeyBag = new PKCS12SafeBagBuilder(newPkInfo, keyEncryptor);
+        newKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(newAlias));
+        newKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(newLocalKeyId));
+
+        PKCS12SafeBagBuilder newCertBag = new PKCS12SafeBagBuilder(new JcaX509CertificateHolder(newCert));
+        newCertBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(newAlias));
+        newCertBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(newLocalKeyId));
+
+        PKCS12PfxPduBuilder pfxBuilder = new PKCS12PfxPduBuilder();
+        pfxBuilder.addData(legacyKeyBag.build());
+        pfxBuilder.addData(newKeyBag.build());
+        pfxBuilder.addEncryptedData(certEncryptor, newCertBag.build());
+
+        PKCS12PfxPdu pfx = pfxBuilder.build(new JcePKCS12MacCalculatorBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME), password);
+
+        return pfx.getEncoded("DER");
+    }
+
+    /**
+     * Applies the same in-process migration logic used by
+     * {@link V202604211200__MigrateMLKEMKeyStorageFormat}: for every alias that has no certificate
+     * and whose recovered key has an algorithm starting with {@code "ML-KEM"}, replaces the bare
+     * key bag with a proper PrivateKeyEntry + orphan cert.
+     *
+     * <p>The public key is supplied via the {@code publicKeys} map (simulating the lookup that the
+     * real migration performs against the {@code key_data} table).
+     *
+     * @return {@code true} if at least one entry was migrated.
+     */
+    private static boolean applyMigrationLogic(KeyStore ks, java.util.Map<String, PublicKey> publicKeys) throws Exception {
+        boolean modified = false;
+        Enumeration<String> aliases = ks.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            if (ks.getCertificate(alias) != null) {
+                continue; // already new format
+            }
+            Key key = ks.getKey(alias, PASSWORD.toCharArray());
+            if (key == null || !key.getAlgorithm().startsWith("ML-KEM")) {
+                continue;
+            }
+            PublicKey publicKey = publicKeys.get(alias);
+            assertNotNull(publicKey, "Public key must be provided for alias: " + alias);
+
+            KeyPair kp = new KeyPair(publicKey, (PrivateKey) key);
+            X509Certificate orphanCert = X509Util.generateMLKEMOrphanX509Certificate(kp);
+            ks.deleteEntry(alias);
+            ks.setKeyEntry(alias, (PrivateKey) key, PASSWORD.toCharArray(), new Certificate[]{orphanCert});
+            modified = true;
+        }
+        return modified;
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void legacyFormatIsDetectedAndMigrated() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+        byte[] legacyBytes = buildLegacyKeystore(mlkemPair);
+
+        // Verify the legacy keystore really has no certificate for the alias.
+        KeyStore legacyKs = KeyStoreUtil.loadKeystore(legacyBytes, PASSWORD);
+        assertNull(legacyKs.getCertificate(ALIAS),
+                "Legacy keystore must have no certificate for ML-KEM alias");
+
+        // Run migration logic.
+        java.util.Map<String, PublicKey> publicKeys = new java.util.HashMap<>();
+        publicKeys.put(ALIAS, mlkemPair.getPublic());
+        boolean modified = applyMigrationLogic(legacyKs, publicKeys);
+
+        assertTrue(modified, "Migration must report that it modified the keystore");
+
+        // After migration the alias must have a certificate.
+        Certificate migratedCert = legacyKs.getCertificate(ALIAS);
+        assertNotNull(migratedCert, "Migrated keystore must have a certificate for ML-KEM alias");
+
+        // The certificate's public key must match the original ML-KEM public key.
+        assertArrayEquals(
+                mlkemPair.getPublic().getEncoded(),
+                migratedCert.getPublicKey().getEncoded(),
+                "Certificate public key must match the original ML-KEM public key");
+
+        // The private key must still be recoverable after migration.
+        Key recoveredKey = legacyKs.getKey(ALIAS, PASSWORD.toCharArray());
+        assertNotNull(recoveredKey, "Private key must be recoverable after migration");
+        assertTrue(recoveredKey.getAlgorithm().startsWith("ML-KEM"),
+                "Recovered key algorithm must start with ML-KEM");
+        assertArrayEquals(
+                mlkemPair.getPrivate().getEncoded(),
+                recoveredKey.getEncoded(),
+                "Recovered private key bytes must match original");
+    }
+
+    @Test
+    void newFormatIsNotModified() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+        byte[] newFormatBytes = buildNewFormatKeystore(mlkemPair);
+
+        KeyStore newKs = KeyStoreUtil.loadKeystore(newFormatBytes, PASSWORD);
+        assertNotNull(newKs.getCertificate(ALIAS),
+                "New-format keystore must already have a certificate");
+
+        java.util.Map<String, PublicKey> publicKeys = new java.util.HashMap<>();
+        publicKeys.put(ALIAS, mlkemPair.getPublic());
+        boolean modified = applyMigrationLogic(newKs, publicKeys);
+
+        assertFalse(modified, "Migration must not modify an already-new-format keystore");
+    }
+
+    @Test
+    void nonMlkemBareEntryIsIgnored() throws Exception {
+        // Store an EC key in bare-bytes format (unusual but should not be touched by this migration).
+        KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        ecKpg.initialize(new java.security.spec.ECGenParameterSpec("P-256"));
+        KeyPair ecPair = ecKpg.generateKeyPair();
+
+        // Build a PKCS12 with a bare EC key bag (no cert) using the low-level builder, then load
+        // it via the standard path so the KeyStore is in the state the migration would encounter.
+        byte[] keystoreBytes = buildBareKeyPkcs12("ec-key", ecPair.getPrivate(), PASSWORD.toCharArray());
+        KeyStore ks = KeyStoreUtil.loadKeystore(keystoreBytes, PASSWORD);
+
+        java.util.Map<String, PublicKey> publicKeys = new java.util.HashMap<>();
+        boolean modified = applyMigrationLogic(ks, publicKeys);
+
+        assertFalse(modified, "Migration must not touch non-ML-KEM bare key entries");
+        assertNull(ks.getCertificate("ec-key"),
+                "EC bare entry must remain untouched (no certificate added)");
+    }
+
+    @Test
+    void mixedKeystoreMigratesOnlyMlkemEntry() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        // Generate a regular EC key stored in the new (normal) format alongside the legacy ML-KEM key.
+        KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        ecKpg.initialize(new java.security.spec.ECGenParameterSpec("P-256"));
+        KeyPair ecPair = ecKpg.generateKeyPair();
+        X509Certificate ecCert = X509Util.generateEcdsaOrphanX509Certificate(ecPair);
+
+        // Build a PKCS12 that holds both a legacy ML-KEM key (bare, no cert) and a normal EC
+        // entry (key + cert) using the low-level builder.
+        byte[] keystoreBytes = buildMixedPkcs12(ALIAS, mlkemPair.getPrivate(), "ec-key", ecPair.getPrivate(), ecCert);
+        KeyStore ks = KeyStoreUtil.loadKeystore(keystoreBytes, PASSWORD);
+
+        java.util.Map<String, PublicKey> publicKeys = new java.util.HashMap<>();
+        publicKeys.put(ALIAS, mlkemPair.getPublic());
+        boolean modified = applyMigrationLogic(ks, publicKeys);
+
+        assertTrue(modified);
+        assertNotNull(ks.getCertificate(ALIAS), "ML-KEM alias must now have a certificate");
+        assertNotNull(ks.getCertificate("ec-key"), "EC alias must still have its original certificate");
+    }
+}


### PR DESCRIPTION
Included fixes:
- RSA encrypt now uses the public key (was using the private key)
- OAEP with non-matching MGF1 hash is now handled via explicit OAEPParameterSpec
- NPE fix: createAndSaveKeyData populates TokenInstance reference
- Encrypt/Decrypt validate key type before use
- ML-KEM keystore format migration (V202604211200)