### PR TITLE
Cache database access for cryptographic operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>software-cryptography-provider</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <name>CZERTAINLY-Software-Cryptography-Provider</name>
 
     <properties>
@@ -22,7 +22,6 @@
     </properties>
 
     <dependencies>
-        <!-- 3Key -->
         <dependency>
             <groupId>com.czertainly</groupId>
             <artifactId>interfaces</artifactId>
@@ -67,6 +66,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
         </dependency>
 
         <dependency>

--- a/scripts/perf/connector-sign.js
+++ b/scripts/perf/connector-sign.js
@@ -1,0 +1,376 @@
+/**
+ * k6 Script — Software Cryptography Provider: Sign Operation on an RSA private key
+ *
+ * Invokes the sign endpoint directly on the connector (no ILM Core, no authentication).
+ * A dedicated token instance and RSA key pair are created in setup() and destroyed in teardown().
+ *
+ * Endpoints used:
+ *   POST   /v1/cryptographyProvider/tokens                                  (setup: create token)
+ *   POST   /v1/cryptographyProvider/tokens/{tokenUuid}/keys/pair            (setup: create key pair)
+ *   POST   /v1/cryptographyProvider/tokens/{tokenUuid}/keys/{keyUuid}/sign  (benchmarking loop)
+ *   DELETE /v1/cryptographyProvider/tokens/{tokenUuid}/keys/{keyUuid}       (teardown: destroy keys)
+ *   DELETE /v1/cryptographyProvider/tokens/{tokenUuid}                      (teardown: remove token if created)
+ *
+ * Usage:
+ *   # Load test — default scenario: 10 VUs, 1 min steady load
+ *   k6 run connector-sign.js
+ *
+ *   # Smoke test (1 VU, 30 s) — enable with SCENARIO=smoke
+ *   k6 run --env SCENARIO=smoke connector-sign.js
+ *
+ *   # Load test with a custom payload
+ *   k6 run --env DATA_B64=$(base64 -i myfile.bin) connector-sign.js
+ *
+ *   # Different algorithm
+ *   k6 run --env SIG_SCHEME=PKCS1-v1_5 --env DIGEST=SHA-256 connector-sign.js
+ *
+ *   # Custom token/key identity
+ *   k6 run --env TOKEN_NAME=myPerfToken --env KEY_ALIAS=myKey --env KEY_SIZE=4096 connector-sign.js
+ *
+ * Environment variables:
+ *   SCENARIO     Scenario to run: smoke | load                  (default: load)
+ *   BASE_URL     Connector base URL                             (default: http://localhost:8230)
+ *   TOKEN_NAME   Name for the ephemeral token instance          (default: k6PerfToken)
+ *   KEY_ALIAS    Alias for the ephemeral key pair               (default: k6RsaKey)
+ *   KEY_SIZE     RSA key size in bits: 1024 | 2048 | 4096       (default: 2048)
+ *   SIG_SCHEME   RSA signature scheme: PSS | PKCS1-v1_5         (default: PSS)
+ *   DIGEST       Digest algorithm: SHA-256 | SHA-384 | SHA-512  (default: SHA-384)
+ *   DATA_B64     Base64-encoded data to sign                    (default: small test string)
+ */
+
+import http from 'k6/http';
+import {check, fail} from 'k6';
+import {Counter} from 'k6/metrics';
+
+// ─── Configuration ────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:8230';
+const TOKEN_NAME = __ENV.TOKEN_NAME || 'k6PerfToken';
+const KEY_ALIAS = __ENV.KEY_ALIAS || 'k6RsaKey';
+const KEY_SIZE = parseInt(__ENV.KEY_SIZE || '2048', 10);
+const SIG_SCHEME = __ENV.SIG_SCHEME || 'PSS';
+const DIGEST = __ENV.DIGEST || 'SHA-384';
+// Default: base64("connector-sign-k6-test")
+const DATA_B64 = __ENV.DATA_B64 || 'Y29ubmVjdG9yLXNpZ24tazYtdGVzdA==';
+const SCENARIO = __ENV.SCENARIO || 'load';   // smoke | load | stress | soak
+
+// ─── k6 Options ───────────────────────────────────────────────────────────────
+
+const scenarios = {
+    smoke: {
+        executor: 'constant-vus',
+        vus: 1,
+        duration: '30s',
+    },
+
+    load: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            {duration: '5s', target: 10},   // ramp-up
+            {duration: '60s', target: 10},   // steady load
+            {duration: '5s', target: 0},   // ramp-down
+        ],
+    },
+};
+
+export const options = {
+    scenarios: {
+        sign: scenarios[SCENARIO],
+    },
+
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)', 'p(99.9)'],
+
+    thresholds: {
+        http_req_duration: ['p(95)<500', 'p(99)<2000'],
+        http_req_failed: ['rate<0.01'],
+        checks: ['rate>0.99'],
+    },
+};
+
+// ─── Metrics ──────────────────────────────────────────────────────────────────
+
+const requestCount = new Counter('sign_requests_total');
+
+// ─── Setup (runs once, result passed to every VU) ─────────────────────────────
+
+export function setup() {
+    const jsonHeaders = {'Content-Type': 'application/json', 'Accept': 'application/json'};
+
+    // 1. Discover token creation attributes.
+    // GET /v1/cryptographyProvider/SOFT/attributes returns different attribute sets
+    // depending on whether tokens already exist:
+    //   - No existing tokens → attributes for new-token creation are returned directly.
+    //   - Existing tokens    → a data_options selector + a group_loadToken group (with
+    //                          a callback) are returned; a separate callback call
+    //                          resolves the new-token sub-attributes.
+    const tokenTopAttrsRes = http.get(`${BASE_URL}/v1/cryptographyProvider/SOFT/attributes`, {headers: jsonHeaders});
+    if (tokenTopAttrsRes.status !== 200) {
+        fail(`Token attribute discovery failed (${tokenTopAttrsRes.status}): ${tokenTopAttrsRes.body}`);
+    }
+    const tokenTopAttrs = tokenTopAttrsRes.json();
+
+    const attrUuid = (attrs, name, contentType) => {
+        const attr = attrs.find(a => a.name === name && (contentType ? a.contentType === contentType : true));
+        if (!attr || !attr.uuid) {
+            fail(`Attribute name='${name}' contentType='${contentType || '(any)'}' not found in: ${JSON.stringify(attrs)}`);
+        }
+        return attr.uuid;
+    };
+
+    let optionsUuid = null;
+    let tokenNewAttrs = null;
+    if (tokenTopAttrs.some(a => a.name === 'data_options')) {
+        optionsUuid = attrUuid(tokenTopAttrs, 'data_options', 'string');
+        const tokenNewAttrsRes = http.get(`${BASE_URL}/v1/cryptographyProvider/callbacks/token/new/attributes`, {headers: jsonHeaders});
+        if (tokenNewAttrsRes.status !== 200) {
+            fail(`Token new-attribute callback failed (${tokenNewAttrsRes.status}): ${tokenNewAttrsRes.body}`);
+        }
+        tokenNewAttrs = tokenNewAttrsRes.json();
+    } else {
+        tokenNewAttrs = tokenTopAttrs;
+    }
+
+    const actionUuid = attrUuid(tokenNewAttrs, 'data_createTokenAction', 'string');
+    const nameUuid = attrUuid(tokenNewAttrs, 'data_newTokenName', 'string');
+    const codeUuid = attrUuid(tokenNewAttrs, 'data_tokenCode', 'secret');
+
+    // 2. Create ephemeral token instance or reuse existing.
+    const tokenPassword = 'k6-test-token-secret';
+
+    let tokenPreexisted = false;
+    const existingTokensRes = http.get(`${BASE_URL}/v1/cryptographyProvider/tokens`, {headers: jsonHeaders});
+    let tokenUuid = null;
+    if (existingTokensRes.status === 200) {
+        const existingTokens = existingTokensRes.json();
+        if (Array.isArray(existingTokens)) {
+            const found = existingTokens.find(t => t.name === TOKEN_NAME);
+            if (found) {
+                tokenUuid = found.uuid;
+                tokenPreexisted = true;
+            }
+        }
+    }
+
+    if (tokenUuid) {
+        console.log(`Token already exists — reusing UUID: ${tokenUuid}`);
+    } else {
+        const attributes = [
+            {
+                uuid: actionUuid,
+                name: 'data_createTokenAction',
+                contentType: 'string',
+                version: 'v2',
+                content: [{reference: 'new', data: 'new'}],
+            },
+            {
+                uuid: nameUuid,
+                name: 'data_newTokenName',
+                contentType: 'string',
+                version: 'v2',
+                content: [{data: TOKEN_NAME}],
+            },
+            {
+                uuid: codeUuid,
+                name: 'data_tokenCode',
+                contentType: 'secret',
+                version: 'v2',
+                content: [{reference: TOKEN_NAME, data: {secret: tokenPassword}}],
+            },
+        ];
+
+        if (optionsUuid) {
+            attributes.push({
+                uuid: optionsUuid,
+                name: 'data_options',
+                contentType: 'string',
+                version: 'v2',
+                content: [{reference: 'new', data: 'Create new Token'}],
+            });
+        }
+
+        const createTokenRes = http.post(
+            `${BASE_URL}/v1/cryptographyProvider/tokens`,
+            JSON.stringify({
+                name: TOKEN_NAME,
+                kind: 'SOFT',
+                attributes: attributes,
+            }),
+            {headers: jsonHeaders},
+        );
+
+        if (createTokenRes.status !== 200) {
+            fail(`Token creation failed (${createTokenRes.status}): ${createTokenRes.body}`);
+        }
+
+        tokenUuid = createTokenRes.json().uuid;
+    }
+
+    // 3. Discover key-pair creation attributes.
+    // GET /v1/cryptographyProvider/tokens/{tokenUuid}/keys/pair/attributes returns:
+    //   data_keyAlias (string), data_keyAlgorithm (string), group_keySpec (group).
+    const keyPairAttrDefsRes = http.get(`${BASE_URL}/v1/cryptographyProvider/tokens/${tokenUuid}/keys/pair/attributes`, {headers: jsonHeaders});
+    if (keyPairAttrDefsRes.status !== 200) {
+        fail(`Key-pair attribute discovery failed (${keyPairAttrDefsRes.status}): ${keyPairAttrDefsRes.body}`);
+    }
+    const keyPairAttrDefs = keyPairAttrDefsRes.json();
+
+    const aliasUuid = attrUuid(keyPairAttrDefs, 'data_keyAlias', 'string');
+    const algUuid = attrUuid(keyPairAttrDefs, 'data_keyAlgorithm', 'string');
+
+    // For RSA: GET /v1/cryptographyProvider/callbacks/keyspec/RSA/attributes
+    //   returns data_rsaKeySize (integer).
+    const rsaSpecAttrsRes = http.get(`${BASE_URL}/v1/cryptographyProvider/callbacks/keyspec/RSA/attributes`, {headers: jsonHeaders});
+    if (rsaSpecAttrsRes.status !== 200) {
+        fail(`RSA keyspec attribute callback failed (${rsaSpecAttrsRes.status}): ${rsaSpecAttrsRes.body}`);
+    }
+    const rsaSpecAttrs = rsaSpecAttrsRes.json();
+    const sizeUuid = attrUuid(rsaSpecAttrs, 'data_rsaKeySize', 'integer');
+
+    // 4. Create RSA key pair inside the token.
+    const createKeyRes = http.post(
+        `${BASE_URL}/v1/cryptographyProvider/tokens/${tokenUuid}/keys/pair`,
+        JSON.stringify({
+            tokenProfileAttributes: [],
+            createKeyAttributes: [
+                {
+                    uuid: aliasUuid,
+                    name: 'data_keyAlias',
+                    contentType: 'string',
+                    version: 'v2',
+                    content: [{data: KEY_ALIAS}],
+                },
+                {
+                    uuid: algUuid,
+                    name: 'data_keyAlgorithm',
+                    contentType: 'string',
+                    version: 'v2',
+                    content: [{reference: 'RSA', data: 'RSA'}],
+                },
+                {
+                    uuid: sizeUuid,
+                    name: 'data_rsaKeySize',
+                    contentType: 'integer',
+                    version: 'v2',
+                    content: [{reference: `RSA_${KEY_SIZE}`, data: KEY_SIZE}],
+                },
+            ],
+        }),
+        {headers: jsonHeaders},
+    );
+
+    if (createKeyRes.status !== 200) {
+        // Best-effort cleanup before aborting.
+        if (!tokenPreexisted) {
+            http.del(`${BASE_URL}/v1/cryptographyProvider/tokens/${tokenUuid}`);
+        }
+        fail(`Key pair creation failed (${createKeyRes.status}): ${createKeyRes.body}`);
+    }
+
+    const keyPair = createKeyRes.json();
+    const privateKeyUuid = keyPair.privateKeyData.uuid;
+    const publicKeyUuid = keyPair.publicKeyData.uuid;
+
+    // 5. Build the sign URL and payload used by every VU.
+    const url = `${BASE_URL}/v1/cryptographyProvider/tokens/${tokenUuid}/keys/${privateKeyUuid}/sign`;
+
+    // Connector matches signatureAttributes by name, not UUID.
+    const payload = JSON.stringify({
+        signatureAttributes: [
+            {
+                name: 'data_rsaSigScheme',
+                contentType: 'string',
+                version: 'v2',
+                content: [{data: SIG_SCHEME}],
+            },
+            {
+                name: 'data_sigDigest',
+                contentType: 'string',
+                version: 'v2',
+                content: [{data: DIGEST}],
+            },
+        ],
+        data: [{data: DATA_B64}],
+    });
+
+    return {url, payload, tokenUuid, privateKeyUuid, publicKeyUuid, tokenPreexisted};
+}
+
+// ─── Default VU function ──────────────────────────────────────────────────────
+
+export default function (data) {
+    const res = http.post(data.url, data.payload, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        },
+    });
+
+    requestCount.add(1);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'response has signatures array': (r) => {
+            try {
+                const body = r.json();
+                return Array.isArray(body.signatures) && body.signatures.length > 0;
+            } catch (_) {
+                return false;
+            }
+        },
+        'signatures[0].data is non-empty': (r) => {
+            try {
+                const sig = r.json().signatures[0].data;
+                return typeof sig === 'string' && sig.length > 0;
+            } catch (_) {
+                return false;
+            }
+        },
+    });
+}
+
+// ─── Teardown (runs once after all VUs finish) ────────────────────────────────
+
+export function teardown(data) {
+    if (!data || !data.tokenUuid) return;
+
+    // Destroy the private and public keys, then remove the token instance.
+    if (data.privateKeyUuid) {
+        http.del(`${BASE_URL}/v1/cryptographyProvider/tokens/${data.tokenUuid}/keys/${data.privateKeyUuid}`);
+    }
+    if (data.publicKeyUuid) {
+        http.del(`${BASE_URL}/v1/cryptographyProvider/tokens/${data.tokenUuid}/keys/${data.publicKeyUuid}`);
+    }
+    if (!data.tokenPreexisted) {
+        http.del(`${BASE_URL}/v1/cryptographyProvider/tokens/${data.tokenUuid}`);
+    }
+}
+
+// ─── Custom summary ───────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+    const duration = data.state.testRunDurationMs / 1000;
+    const total = data.metrics['http_reqs']?.values?.count ?? 0;
+    const throughput = (total / duration).toFixed(2);
+
+    const p95 = (data.metrics['http_req_duration']?.values?.['p(95)'] ?? 0).toFixed(2);
+    const p99 = (data.metrics['http_req_duration']?.values?.['p(99)'] ?? 0).toFixed(2);
+
+    const lines = [
+        '',
+        '┌────────────────────────────────────────┐',
+        '│           SIGN OPERATION SUMMARY       │',
+        '├────────────────────────────────────────┤',
+        `│  Total requests : ${String(total).padEnd(20)} │`,
+        `│  Duration       : ${(duration.toFixed(1) + ' s').padEnd(20)} │`,
+        `│  Throughput     : ${(throughput + ' req/s').padEnd(20)} │`,
+        `│  p(95) latency  : ${(p95 + ' ms').padEnd(20)} │`,
+        `│  p(99) latency  : ${(p99 + ' ms').padEnd(20)} │`,
+        '└────────────────────────────────────────┘',
+        '',
+    ].join('\n');
+
+    return {
+        stdout: lines,
+    };
+}

--- a/src/main/java/com/czertainly/cp/soft/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/czertainly/cp/soft/ExceptionHandlingAdvice.java
@@ -147,7 +147,7 @@ public class ExceptionHandlingAdvice {
         }
         ApiErrorResponseDto apiErrorResponseDto = new ApiErrorResponseDto(702, HttpStatus.BAD_REQUEST, "Cryptographic operation problem", errorMessage);
         apiErrorResponseDto.setTimestamp(Instant.now().toEpochMilli());
-        log.error(apiErrorResponseDto.getMessage() + ": " + ExceptionUtils.getStackTrace(ex));
+        log.error("{}: {}", apiErrorResponseDto.getMessage(), ExceptionUtils.getStackTrace(ex));
         return new ResponseEntity<>(
                 apiErrorResponseDto, new HttpHeaders(), apiErrorResponseDto.getStatus());
     }

--- a/src/main/java/com/czertainly/cp/soft/ExceptionHandlingAdvice.java
+++ b/src/main/java/com/czertainly/cp/soft/ExceptionHandlingAdvice.java
@@ -3,6 +3,7 @@ package com.czertainly.cp.soft;
 import com.czertainly.api.exception.*;
 import com.czertainly.cp.soft.dto.ApiErrorResponseDto;
 import com.czertainly.cp.soft.dto.ErrorMessageDto;
+import com.czertainly.cp.soft.exception.CryptographicOperationException;
 import com.czertainly.cp.soft.exception.NotSupportedException;
 import com.czertainly.cp.soft.exception.TokenInstanceException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -136,6 +137,19 @@ public class ExceptionHandlingAdvice {
         return ex.getErrors().stream()
                 .map(ValidationError::getErrorDescription)
                 .collect(Collectors.toList());
+    }
+
+    @ExceptionHandler(CryptographicOperationException.class)
+    public ResponseEntity<Object> handleCryptographicOperationException(CryptographicOperationException ex) {
+        ErrorMessageDto errorMessage = new ErrorMessageDto(ex.getMessage(), ex.getClass().getSimpleName(), null);
+        if (log.isDebugEnabled()) {
+            errorMessage.setStacktrace(ExceptionUtils.getStackTrace(ex));
+        }
+        ApiErrorResponseDto apiErrorResponseDto = new ApiErrorResponseDto(702, HttpStatus.BAD_REQUEST, "Cryptographic operation problem", errorMessage);
+        apiErrorResponseDto.setTimestamp(Instant.now().toEpochMilli());
+        log.error(apiErrorResponseDto.getMessage() + ": " + ExceptionUtils.getStackTrace(ex));
+        return new ResponseEntity<>(
+                apiErrorResponseDto, new HttpHeaders(), apiErrorResponseDto.getStatus());
     }
 
     @ExceptionHandler(TokenInstanceException.class)

--- a/src/main/java/com/czertainly/cp/soft/config/CacheConfig.java
+++ b/src/main/java/com/czertainly/cp/soft/config/CacheConfig.java
@@ -1,0 +1,49 @@
+package com.czertainly.cp.soft.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String KEYSTORES_CACHE = "keystores";
+    public static final String KEYDATA_CACHE = "keydata";
+
+    @Value("${provider.cache.keystore.ttl-seconds:60}")
+    private long keyStoreTtlSeconds;
+
+    @Value("${provider.cache.keystore.max-size:500}")
+    private long keyStoreMaxSize;
+
+    @Value("${provider.cache.keydata.ttl-seconds:300}")
+    private long keyDataTtlSeconds;
+
+    @Value("${provider.cache.keydata.max-size:10000}")
+    private long keyDataMaxSize;
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.registerCustomCache(KEYSTORES_CACHE,
+                Caffeine.newBuilder()
+                        .expireAfterWrite(keyStoreTtlSeconds, TimeUnit.SECONDS)
+                        .maximumSize(keyStoreMaxSize)
+                        .recordStats()
+                        .build());
+        manager.registerCustomCache(KEYDATA_CACHE,
+                Caffeine.newBuilder()
+                        .expireAfterWrite(keyDataTtlSeconds, TimeUnit.SECONDS)
+                        .maximumSize(keyDataMaxSize)
+                        .recordStats()
+                        .build());
+        return manager;
+    }
+}

--- a/src/main/java/com/czertainly/cp/soft/model/CachedKeyData.java
+++ b/src/main/java/com/czertainly/cp/soft/model/CachedKeyData.java
@@ -1,0 +1,27 @@
+package com.czertainly.cp.soft.model;
+
+import com.czertainly.api.model.common.attribute.common.MetadataAttribute;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyFormat;
+import com.czertainly.api.model.common.enums.cryptography.KeyType;
+import com.czertainly.api.model.connector.cryptography.key.value.KeyValue;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Immutable, session-detached snapshot of a {@code KeyData} row for the crypto hot path.
+ */
+public record CachedKeyData(
+        UUID uuid,
+        UUID tokenInstanceUuid,
+        String alias,
+        String association,
+        KeyType type,
+        KeyAlgorithm algorithm,
+        KeyFormat format,
+        KeyValue value,
+        int length,
+        List<MetadataAttribute> metadata
+) {
+}

--- a/src/main/java/com/czertainly/cp/soft/model/CachedKeyMaterial.java
+++ b/src/main/java/com/czertainly/cp/soft/model/CachedKeyMaterial.java
@@ -1,0 +1,28 @@
+package com.czertainly.cp.soft.model;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Map;
+
+/**
+ * Immutable snapshot of the key material extracted from a PKCS12 keystore.
+ *
+ * <p>Both maps are unmodifiable and populated once at cache-load time. Instances
+ * of this record are safe for concurrent reads with no synchronization because:</p>
+ * <ul>
+ *   <li>The {@link PrivateKey} implementations used here ({@code BCRSAPrivateCrtKey}, {@code BCECPrivateKey},
+ *   {@code BCFalconPrivateKey}, {@code BCMLDSAPrivateKey}, {@code BCSLHDSAPrivateKey}) store all key material
+ *   in {@code byte[]} fields set at construction time. No mutable state accumulates on subsequent method calls.</li>
+ *   <li>{@link PublicKey} implementations are immutable by the same verification.</li>
+ *   <li>Both maps are wrapped in {@code Collections.unmodifiableMap()} and are never replaced or modified after construction.</li>
+ * </ul>
+ *
+ * <p>Keys are indexed by alias, which equals {@code KeyData.name} for every entry in this connector.</p>
+ *
+ * <p>The underlying {@code KeyStore} is used only during construction and is immediately discarded.</p>
+ */
+public record CachedKeyMaterial(
+        Map<String, PrivateKey> privateKeys,
+        Map<String, PublicKey> publicKeys
+) {
+}

--- a/src/main/java/com/czertainly/cp/soft/service/KeyDataCacheService.java
+++ b/src/main/java/com/czertainly/cp/soft/service/KeyDataCacheService.java
@@ -1,0 +1,25 @@
+package com.czertainly.cp.soft.service;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.cp.soft.model.CachedKeyData;
+
+import java.util.UUID;
+
+public interface KeyDataCacheService {
+
+    /**
+     * Returns the cached {@link CachedKeyData} DTO for the given key UUID, loading it from the {@code key_data} table
+     * on a cache miss and serving it from the Caffeine "keydata" cache on a hit.
+     *
+     * <p>The cache key is {@code keyUuid}.</p>
+     *
+     * @throws NotFoundException if no row exists for the given UUID.
+     */
+    CachedKeyData getCachedKeyData(UUID keyUuid) throws NotFoundException;
+
+    /**
+     * Schedules eviction of the cached DTO for the given key UUID so that it fires <em>after</em> the surrounding
+     * database transaction commits. If called outside an active transaction, the eviction is applied immediately.
+     */
+    void evictAfterCommit(UUID keyUuid);
+}

--- a/src/main/java/com/czertainly/cp/soft/service/KeyStoreCacheService.java
+++ b/src/main/java/com/czertainly/cp/soft/service/KeyStoreCacheService.java
@@ -1,0 +1,25 @@
+package com.czertainly.cp.soft.service;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
+
+import java.util.UUID;
+
+public interface KeyStoreCacheService {
+
+    /**
+     * Returns the extracted key material for the token with the given UUID, loading it from the database on a cache miss
+     * and serving it from the Caffeine "keystores" cache on a hit.
+     *
+     * <p>On a cache miss the service resolves the {@code TokenInstance} internally via {@code TokenInstanceRepository}.</p>
+     *
+     * @throws NotFoundException if no token instance exists for the given UUID.
+     */
+    CachedKeyMaterial loadKeyMaterial(UUID tokenInstanceUuid) throws NotFoundException;
+
+    /**
+     * Schedules eviction of the cached key material for the given token instance UUID so that it fires <em>after</em>
+     * the surrounding database transaction commits. If called outside an active transaction, the eviction is applied immediately.
+     */
+    void evictAfterCommit(UUID tokenInstanceUuid);
+}

--- a/src/main/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsServiceImpl.java
@@ -6,10 +6,12 @@ import com.czertainly.api.model.connector.cryptography.operations.*;
 import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
 import com.czertainly.api.model.connector.cryptography.operations.data.SignatureResponseData;
 import com.czertainly.api.model.connector.cryptography.operations.data.VerificationResponseData;
-import com.czertainly.cp.soft.dao.entity.KeyData;
 import com.czertainly.cp.soft.exception.CryptographicOperationException;
 import com.czertainly.cp.soft.service.CryptographicOperationsService;
-import com.czertainly.cp.soft.service.KeyManagementService;
+import com.czertainly.cp.soft.service.KeyDataCacheService;
+import com.czertainly.cp.soft.service.KeyStoreCacheService;
+import com.czertainly.cp.soft.model.CachedKeyData;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
 import com.czertainly.cp.soft.util.CipherUtil;
 import com.czertainly.cp.soft.util.SecureRandomUtil;
 import com.czertainly.cp.soft.util.SignatureUtil;
@@ -27,30 +29,23 @@ import java.util.UUID;
 
 @Service
 public class CryptographicOperationsServiceImpl implements CryptographicOperationsService {
-
-    private KeyManagementService keyManagementService;
-
-    @Autowired
-    public void setKeyManagementService(KeyManagementService keyManagementService) {
-        this.keyManagementService = keyManagementService;
-    }
+    private KeyDataCacheService keyDataCacheService;
+    private KeyStoreCacheService keyStoreCacheService;
 
     @Override
     public SignDataResponseDto signData(UUID uuid, UUID keyUuid, SignDataRequestDto request) throws NotFoundException {
-        // check that the key exists
-        // if the key exists, the token instance should exist too
-        KeyData key = keyManagementService.getKeyEntity(uuid, keyUuid);
+        CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
 
         // check if we are going to sign with private key
-        if (key.getType() != KeyType.PRIVATE_KEY) {
+        if (key.type() != KeyType.PRIVATE_KEY) {
             throw new CryptographicOperationException("Only private keys can be used for signing.");
         }
 
+        CachedKeyMaterial material = keyStoreCacheService.loadKeyMaterial(key.tokenInstanceUuid());
         // initialize signature with the algorithm
         Signature signature = SignatureUtil.prepareSignature(key, request.getSignatureAttributes());
-
         // initialize the signature with the private key
-        SignatureUtil.initSigning(signature, key);
+        SignatureUtil.initSigning(signature, key, material);
 
         // sign the data, it can be a list, so we need to iterate over it
         SignDataResponseDto response = new SignDataResponseDto();
@@ -73,20 +68,18 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
 
     @Override
     public VerifyDataResponseDto verifyData(UUID uuid, UUID keyUuid, VerifyDataRequestDto request) throws NotFoundException {
-        // check that the key exists
-        // if the key exists, the token instance should exist too
-        KeyData key = keyManagementService.getKeyEntity(uuid, keyUuid);
+        CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
 
-        // check if we are going to sign with private key
-        if (key.getType() != KeyType.PUBLIC_KEY) {
+        // check if we are going to verify with public key
+        if (key.type() != KeyType.PUBLIC_KEY) {
             throw new CryptographicOperationException("Only public keys can be used for verification.");
         }
 
+        CachedKeyMaterial material = keyStoreCacheService.loadKeyMaterial(key.tokenInstanceUuid());
         // initialize signature with the algorithm
         Signature signature = SignatureUtil.prepareSignature(key, request.getSignatureAttributes());
-
         // initialize the signature with the private key
-        SignatureUtil.initVerification(signature, key);
+        SignatureUtil.initVerification(signature, key, material);
 
         // verify the data, it can be a list, so we need to iterate over it
         VerifyDataResponseDto response = new VerifyDataResponseDto();
@@ -109,10 +102,6 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
             verifications.add(verificationResponseData);
         }
 
-        request.getSignatures().forEach(data -> {
-
-        });
-
         response.setVerifications(verifications);
         return response;
     }
@@ -130,19 +119,37 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
 
     @Override
     public DecryptDataResponseDto decryptData(UUID uuid, UUID keyUuid, CipherDataRequestDto request) throws NotFoundException {
-        KeyData key = keyManagementService.getKeyEntity(uuid, keyUuid);
-        if (key.getType() != KeyType.PRIVATE_KEY) {
+        CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
+
+        // check if we are going to decrypt with private key
+        if (key.type() != KeyType.PRIVATE_KEY) {
             throw new CryptographicOperationException("Only private keys can be used for decryption.");
         }
-        return CipherUtil.decrypt(request, key);
+
+        CachedKeyMaterial material = keyStoreCacheService.loadKeyMaterial(key.tokenInstanceUuid());
+        return CipherUtil.decrypt(request, key, material);
     }
 
     @Override
     public EncryptDataResponseDto encryptData(UUID uuid, UUID keyUuid, CipherDataRequestDto request) throws NotFoundException {
-        KeyData key = keyManagementService.getKeyEntity(uuid, keyUuid);
-        if (key.getType() != KeyType.PUBLIC_KEY) {
+        CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
+
+        // check if we are going to encrypt with public key
+        if (key.type() != KeyType.PUBLIC_KEY) {
             throw new CryptographicOperationException("Only public keys can be used for encryption.");
         }
-        return CipherUtil.encrypt(request, key);
+
+        CachedKeyMaterial material = keyStoreCacheService.loadKeyMaterial(key.tokenInstanceUuid());
+        return CipherUtil.encrypt(request, key, material);
+    }
+
+    @Autowired
+    public void setKeyDataCacheService(KeyDataCacheService keyDataCacheService) {
+        this.keyDataCacheService = keyDataCacheService;
+    }
+
+    @Autowired
+    public void setKeyStoreCacheService(KeyStoreCacheService keyStoreCacheService) {
+        this.keyStoreCacheService = keyStoreCacheService;
     }
 }

--- a/src/main/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsServiceImpl.java
@@ -6,6 +6,7 @@ import com.czertainly.api.model.connector.cryptography.operations.*;
 import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
 import com.czertainly.api.model.connector.cryptography.operations.data.SignatureResponseData;
 import com.czertainly.api.model.connector.cryptography.operations.data.VerificationResponseData;
+import com.czertainly.cp.soft.dao.entity.TokenInstance;
 import com.czertainly.cp.soft.exception.CryptographicOperationException;
 import com.czertainly.cp.soft.service.CryptographicOperationsService;
 import com.czertainly.cp.soft.service.KeyDataCacheService;
@@ -35,6 +36,10 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
     @Override
     public SignDataResponseDto signData(UUID uuid, UUID keyUuid, SignDataRequestDto request) throws NotFoundException {
         CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
+
+        if (!uuid.equals(key.tokenInstanceUuid())) {
+            throw new NotFoundException(TokenInstance.class, uuid);
+        }
 
         // check if we are going to sign with private key
         if (key.type() != KeyType.PRIVATE_KEY) {
@@ -69,6 +74,10 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
     @Override
     public VerifyDataResponseDto verifyData(UUID uuid, UUID keyUuid, VerifyDataRequestDto request) throws NotFoundException {
         CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
+
+        if (!uuid.equals(key.tokenInstanceUuid())) {
+            throw new NotFoundException(TokenInstance.class, uuid);
+        }
 
         // check if we are going to verify with public key
         if (key.type() != KeyType.PUBLIC_KEY) {
@@ -121,6 +130,10 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
     public DecryptDataResponseDto decryptData(UUID uuid, UUID keyUuid, CipherDataRequestDto request) throws NotFoundException {
         CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
 
+        if (!uuid.equals(key.tokenInstanceUuid())) {
+            throw new NotFoundException(TokenInstance.class, uuid);
+        }
+
         // check if we are going to decrypt with private key
         if (key.type() != KeyType.PRIVATE_KEY) {
             throw new CryptographicOperationException("Only private keys can be used for decryption.");
@@ -133,6 +146,10 @@ public class CryptographicOperationsServiceImpl implements CryptographicOperatio
     @Override
     public EncryptDataResponseDto encryptData(UUID uuid, UUID keyUuid, CipherDataRequestDto request) throws NotFoundException {
         CachedKeyData key = keyDataCacheService.getCachedKeyData(keyUuid);
+
+        if (!uuid.equals(key.tokenInstanceUuid())) {
+            throw new NotFoundException(TokenInstance.class, uuid);
+        }
 
         // check if we are going to encrypt with public key
         if (key.type() != KeyType.PUBLIC_KEY) {

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyDataCacheServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyDataCacheServiceImpl.java
@@ -1,0 +1,80 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.cp.soft.config.CacheConfig;
+import com.czertainly.cp.soft.dao.entity.KeyData;
+import com.czertainly.cp.soft.dao.repository.KeyDataRepository;
+import com.czertainly.cp.soft.service.KeyDataCacheService;
+import com.czertainly.cp.soft.model.CachedKeyData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class KeyDataCacheServiceImpl implements KeyDataCacheService {
+
+    private static final Logger logger = LoggerFactory.getLogger(KeyDataCacheServiceImpl.class);
+
+    private final CacheManager cacheManager;
+    private final KeyDataRepository keyDataRepository;
+
+    public KeyDataCacheServiceImpl(CacheManager cacheManager, KeyDataRepository keyDataRepository) {
+        this.cacheManager = cacheManager;
+        this.keyDataRepository = keyDataRepository;
+    }
+
+    @Override
+    @Cacheable(value = CacheConfig.KEYDATA_CACHE, key = "#keyUuid", sync = true)
+    public CachedKeyData getCachedKeyData(UUID keyUuid) throws NotFoundException {
+        logger.debug("Cache miss — loading KeyData {} from database", keyUuid);
+
+        KeyData entity = keyDataRepository.findByUuid(keyUuid)
+                .orElseThrow(() -> new NotFoundException(KeyData.class, keyUuid));
+
+        var md = entity.getMetadata();
+        return new CachedKeyData(
+                entity.getUuid(),
+                entity.getTokenInstanceUuid(),
+                entity.getName(),
+                entity.getAssociation(),
+                entity.getType(),
+                entity.getAlgorithm(),
+                entity.getFormat(),
+                entity.getValue(),
+                entity.getLength(),
+                md != null ? Collections.unmodifiableList(md) : List.of()
+        );
+    }
+
+    @Override
+    public void evictAfterCommit(UUID keyUuid) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    doEvict(keyUuid);
+                }
+            });
+        } else {
+            logger.debug("evictAfterCommit called outside a transaction for key {}; evicting immediately", keyUuid);
+            doEvict(keyUuid);
+        }
+    }
+
+    private void doEvict(UUID keyUuid) {
+        Cache cache = cacheManager.getCache(CacheConfig.KEYDATA_CACHE);
+        if (cache != null) {
+            cache.evict(keyUuid);
+            logger.debug("Evicted cached KeyData {}", keyUuid);
+        }
+    }
+}

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
@@ -274,13 +274,8 @@ public class KeyManagementServiceImpl implements KeyManagementService {
         KeyData key = keyDataRepository.findByUuid(keyUuid)
                 .orElseThrow(() -> new NotFoundException(KeyData.class, keyUuid));
 
-        // The private-key entry occupies a KeyStore alias together with the paired public key (stored as the certificate
-        // chain on that same alias).  The public key is also persisted in the database as SPKI bytes.  Deleting the
-        // private-key alias removes the certificate chain too, so no separate public-key removal from the KeyStore is needed.
-        //
-        // For PUBLIC_KEY records we skip keystore eviction intentionally: once the DB row is deleted, any subsequent getCachedKeyData()
-        // call will miss the keydata cache → hit the DB → throw NotFoundException before the stale CachedKeyMaterial.publicKeys
-        // entry is ever consulted. The stale keystore entry is therefore harmless and will be evicted naturally at TTL.
+        // remove key from the keystore only if it is private key
+        // public key is removed automatically when private key is removed, however, we can keep it in the database
         if (key.getType() == KeyType.PRIVATE_KEY) {
             removeKeyFromKeyStore(uuid, key.getName());
         }

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
@@ -274,9 +274,9 @@ public class KeyManagementServiceImpl implements KeyManagementService {
         KeyData key = keyDataRepository.findByUuid(keyUuid)
                 .orElseThrow(() -> new NotFoundException(KeyData.class, keyUuid));
 
-        // Only the private-key entry occupies a KeyStore alias; the paired public key is stored only in the database (as SPKI bytes)
-        // and has no separate alias in the PKCS12 store.  Deleting the private-key alias also removes the associated certificate chain, so no
-        // separate public-key removal from the KeyStore is needed.
+        // The private-key entry occupies a KeyStore alias together with the paired public key (stored as the certificate
+        // chain on that same alias).  The public key is also persisted in the database as SPKI bytes.  Deleting the
+        // private-key alias removes the certificate chain too, so no separate public-key removal from the KeyStore is needed.
         //
         // For PUBLIC_KEY records we skip keystore eviction intentionally: once the DB row is deleted, any subsequent getCachedKeyData()
         // call will miss the keydata cache → hit the DB → throw NotFoundException before the stale CachedKeyMaterial.publicKeys

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyManagementServiceImpl.java
@@ -22,6 +22,7 @@ import com.czertainly.cp.soft.dao.entity.TokenInstance;
 import com.czertainly.cp.soft.dao.repository.KeyDataRepository;
 import com.czertainly.cp.soft.exception.KeyManagementException;
 import com.czertainly.cp.soft.exception.TokenInstanceException;
+import com.czertainly.cp.soft.service.KeyDataCacheService;
 import com.czertainly.cp.soft.service.KeyManagementService;
 import com.czertainly.cp.soft.service.TokenInstanceService;
 import com.czertainly.cp.soft.util.KeyStoreUtil;
@@ -44,18 +45,8 @@ import java.util.stream.Collectors;
 public class KeyManagementServiceImpl implements KeyManagementService {
 
     private TokenInstanceService tokenInstanceService;
-
     private KeyDataRepository keyDataRepository;
-
-    @Autowired
-    public void setTokenInstanceService(TokenInstanceService tokenInstanceService) {
-        this.tokenInstanceService = tokenInstanceService;
-    }
-
-    @Autowired
-    public void setKeyDataRepository(KeyDataRepository keyDataRepository) {
-        this.keyDataRepository = keyDataRepository;
-    }
+    private KeyDataCacheService keyDataCacheService;
 
     @Override
     public KeyPairDataResponseDto createKeyPair(UUID uuid, CreateKeyRequestDto request) throws NotFoundException {
@@ -223,7 +214,6 @@ public class KeyManagementServiceImpl implements KeyManagementService {
                 // prepare public key
                 publicKey = createAndSaveKeyData(
                         alias, association, KeyType.PUBLIC_KEY, KeyAlgorithm.SLHDSA, KeyFormat.SPKI,
-                        //KeyStoreUtil.spkiKeyValueFromPrivateKey(keyStore, alias, tokenInstance.getCode()),
                         KeyStoreUtil.spkiKeyValueFromKeyStore(keyStore, alias),
                         slhDsaSecurityCategory.getPublicKeySize(), metadata, tokenInstance);
 
@@ -268,6 +258,8 @@ public class KeyManagementServiceImpl implements KeyManagementService {
         tokenInstance.setData(data);
 
         // save token and return
+        // Note: saveTokenInstance already schedules keystore cache eviction internally
+        // (see TokenInstanceServiceImpl.saveTokenInstance), so no explicit evict call is needed here.
         tokenInstanceService.saveTokenInstance(tokenInstance);
 
         response.setPublicKeyData(publicKey.toKeyDataResponseDto());
@@ -282,14 +274,20 @@ public class KeyManagementServiceImpl implements KeyManagementService {
         KeyData key = keyDataRepository.findByUuid(keyUuid)
                 .orElseThrow(() -> new NotFoundException(KeyData.class, keyUuid));
 
-        // remove key from the keystore only of it is private key
-        // public key is removed automatically when private key is removed, however, we can keep it in the database
+        // Only the private-key entry occupies a KeyStore alias; the paired public key is stored only in the database (as SPKI bytes)
+        // and has no separate alias in the PKCS12 store.  Deleting the private-key alias also removes the associated certificate chain, so no
+        // separate public-key removal from the KeyStore is needed.
+        //
+        // For PUBLIC_KEY records we skip keystore eviction intentionally: once the DB row is deleted, any subsequent getCachedKeyData()
+        // call will miss the keydata cache → hit the DB → throw NotFoundException before the stale CachedKeyMaterial.publicKeys
+        // entry is ever consulted. The stale keystore entry is therefore harmless and will be evicted naturally at TTL.
         if (key.getType() == KeyType.PRIVATE_KEY) {
             removeKeyFromKeyStore(uuid, key.getName());
         }
 
         // delete key from the database
         keyDataRepository.delete(key);
+        keyDataCacheService.evictAfterCommit(keyUuid);
     }
 
     private void removeKeyFromKeyStore(UUID tokenInstanceUuid, String alias) throws NotFoundException {
@@ -356,8 +354,23 @@ public class KeyManagementServiceImpl implements KeyManagementService {
         keyData.setTokenInstance(tokenInstance);
 
         keyDataRepository.save(keyData);
+        keyDataCacheService.evictAfterCommit(keyData.getUuid());
 
         return keyData;
     }
 
+    @Autowired
+    public void setTokenInstanceService(TokenInstanceService tokenInstanceService) {
+        this.tokenInstanceService = tokenInstanceService;
+    }
+
+    @Autowired
+    public void setKeyDataRepository(KeyDataRepository keyDataRepository) {
+        this.keyDataRepository = keyDataRepository;
+    }
+
+    @Autowired
+    public void setKeyDataCacheService(KeyDataCacheService keyDataCacheService) {
+        this.keyDataCacheService = keyDataCacheService;
+    }
 }

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyStoreCacheServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyStoreCacheServiceImpl.java
@@ -68,22 +68,7 @@ public class KeyStoreCacheServiceImpl implements KeyStoreCacheService {
         try {
             Enumeration<String> aliases = ks.aliases();
             while (aliases.hasMoreElements()) {
-                String alias = aliases.nextElement();
-
-                try {
-                    Key key = ks.getKey(alias, code.toCharArray());
-                    if (key instanceof PrivateKey pk) {
-                        privateKeys.put(alias, pk);
-                    }
-                    Certificate cert = ks.getCertificate(alias);
-                    if (cert != null) {
-                        publicKeys.put(alias, cert.getPublicKey());
-                    }
-                } catch (UnrecoverableKeyException | NoSuchAlgorithmException e) {
-                    logger.warn("Skipping alias '{}' — cannot recover key: {}", alias, e.getMessage());
-                } catch (KeyStoreException e) {
-                    logger.warn("Skipping alias '{}' — cannot access key material: {}", alias, e.getMessage());
-                }
+                extractAliasKeyMaterial(ks, aliases.nextElement(), code.toCharArray(), privateKeys, publicKeys);
             }
         } catch (KeyStoreException e) {
             throw new IllegalStateException("Cannot enumerate KeyStore aliases", e);
@@ -93,6 +78,25 @@ public class KeyStoreCacheServiceImpl implements KeyStoreCacheService {
                 Collections.unmodifiableMap(privateKeys),
                 Collections.unmodifiableMap(publicKeys)
         );
+    }
+
+    private void extractAliasKeyMaterial(KeyStore ks, String alias, char[] password,
+                                          Map<String, PrivateKey> privateKeys,
+                                          Map<String, PublicKey> publicKeys) {
+        try {
+            Key key = ks.getKey(alias, password);
+            if (key instanceof PrivateKey pk) {
+                privateKeys.put(alias, pk);
+            }
+            Certificate cert = ks.getCertificate(alias);
+            if (cert != null) {
+                publicKeys.put(alias, cert.getPublicKey());
+            }
+        } catch (UnrecoverableKeyException | NoSuchAlgorithmException e) {
+            throw new IllegalStateException("Cannot recover key for alias '" + alias + "'", e);
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException("Cannot access key material for alias '" + alias + "'", e);
+        }
     }
 
     /**

--- a/src/main/java/com/czertainly/cp/soft/service/impl/KeyStoreCacheServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/KeyStoreCacheServiceImpl.java
@@ -1,0 +1,131 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.cp.soft.config.CacheConfig;
+import com.czertainly.cp.soft.dao.entity.TokenInstance;
+import com.czertainly.cp.soft.dao.repository.TokenInstanceRepository;
+import com.czertainly.cp.soft.exception.TokenInstanceException;
+import com.czertainly.cp.soft.service.KeyStoreCacheService;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class KeyStoreCacheServiceImpl implements KeyStoreCacheService {
+    private static final Logger logger = LoggerFactory.getLogger(KeyStoreCacheServiceImpl.class);
+
+    private final CacheManager cacheManager;
+    private final TokenInstanceRepository tokenInstanceRepository;
+
+    public KeyStoreCacheServiceImpl(CacheManager cacheManager,
+                                    TokenInstanceRepository tokenInstanceRepository) {
+        this.cacheManager = cacheManager;
+        this.tokenInstanceRepository = tokenInstanceRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    @Cacheable(value = CacheConfig.KEYSTORES_CACHE, key = "#tokenInstanceUuid", sync = true)
+    public CachedKeyMaterial loadKeyMaterial(UUID tokenInstanceUuid) throws NotFoundException {
+        logger.debug("Cache miss — loading key material for token instance {} from database",
+                tokenInstanceUuid);
+
+        TokenInstance tokenInstance = tokenInstanceRepository.findByUuid(tokenInstanceUuid)
+                .orElseThrow(() -> new NotFoundException(TokenInstance.class, tokenInstanceUuid));
+
+        String code = tokenInstance.getCode();
+        if (code == null) {
+            throw new TokenInstanceException("Token is not activated.");
+        }
+
+        KeyStore ks = KeyStoreUtil.loadKeystore(tokenInstance.getData(), code);
+
+        Map<String, PrivateKey> privateKeys = new HashMap<>();
+        Map<String, PublicKey>  publicKeys  = new HashMap<>();
+
+        try {
+            Enumeration<String> aliases = ks.aliases();
+            while (aliases.hasMoreElements()) {
+                String alias = aliases.nextElement();
+
+                try {
+                    Key key = ks.getKey(alias, code.toCharArray());
+                    if (key instanceof PrivateKey pk) {
+                        privateKeys.put(alias, pk);
+                    }
+                    Certificate cert = ks.getCertificate(alias);
+                    if (cert != null) {
+                        publicKeys.put(alias, cert.getPublicKey());
+                    }
+                } catch (UnrecoverableKeyException | NoSuchAlgorithmException e) {
+                    logger.warn("Skipping alias '{}' — cannot recover key: {}", alias, e.getMessage());
+                } catch (KeyStoreException e) {
+                    logger.warn("Skipping alias '{}' — cannot access key material: {}", alias, e.getMessage());
+                }
+            }
+        } catch (KeyStoreException e) {
+            throw new IllegalStateException("Cannot enumerate KeyStore aliases", e);
+        }
+
+        return new CachedKeyMaterial(
+                Collections.unmodifiableMap(privateKeys),
+                Collections.unmodifiableMap(publicKeys)
+        );
+    }
+
+    /**
+     * Schedules cache eviction to run after the current transaction commits.
+     *
+     * <p><b>Consistency guarantee (eventual, not strict):</b> eviction fires in the {@code afterCommit} phase of Spring's
+     * transaction synchronization, which runs <em>after</em> the database row has already been made visible to other transactions.</p>
+     *
+     * <p>In the narrow window between commit and the synchronization callback, a concurrent reader <em>could</em> repopulate
+     * the cache with the newly-written value — which is correct — rather than the stale value. This is benign (the cached value
+     * is never stale-after-eviction, only potentially refreshed a few microseconds early), but callers should not assume
+     * strict linearizability between writes and cache state.</p>
+     */
+    @Override
+    public void evictAfterCommit(UUID tokenInstanceUuid) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    doEvict(tokenInstanceUuid);
+                }
+            });
+        } else {
+            logger.debug("evictAfterCommit called outside a transaction for token instance {}; evicting immediately", tokenInstanceUuid);
+            doEvict(tokenInstanceUuid);
+        }
+    }
+
+    private void doEvict(UUID tokenInstanceUuid) {
+        Cache cache = cacheManager.getCache(CacheConfig.KEYSTORES_CACHE);
+        if (cache != null) {
+            cache.evict(tokenInstanceUuid);
+            logger.debug("Evicted cached key material for token instance {}", tokenInstanceUuid);
+        }
+    }
+}

--- a/src/main/java/com/czertainly/cp/soft/service/impl/TokenInstanceServiceImpl.java
+++ b/src/main/java/com/czertainly/cp/soft/service/impl/TokenInstanceServiceImpl.java
@@ -20,6 +20,7 @@ import com.czertainly.cp.soft.attribute.TokenInstanceAttributes;
 import com.czertainly.cp.soft.dao.entity.TokenInstance;
 import com.czertainly.cp.soft.dao.repository.TokenInstanceRepository;
 import com.czertainly.cp.soft.exception.TokenInstanceException;
+import com.czertainly.cp.soft.service.KeyStoreCacheService;
 import com.czertainly.cp.soft.service.TokenInstanceService;
 import com.czertainly.cp.soft.util.KeyStoreUtil;
 import jakarta.transaction.Transactional;
@@ -41,11 +42,7 @@ public class TokenInstanceServiceImpl implements TokenInstanceService {
     private static final Logger logger = LoggerFactory.getLogger(TokenInstanceServiceImpl.class);
 
     private TokenInstanceRepository tokenInstanceRepository;
-
-    @Autowired
-    public void setTokenInstanceRepository(TokenInstanceRepository tokenInstanceRepository) {
-        this.tokenInstanceRepository = tokenInstanceRepository;
-    }
+    private KeyStoreCacheService keyStoreCacheService;
 
     @Value("${token.deleteOnRemove}")
     private boolean deleteOnRemove;
@@ -144,6 +141,7 @@ public class TokenInstanceServiceImpl implements TokenInstanceService {
         } else {
             logger.debug("Delete is disabled, keeping the token instance {} in database", token);
         }
+        keyStoreCacheService.evictAfterCommit(uuid);
     }
 
     @Override
@@ -183,6 +181,7 @@ public class TokenInstanceServiceImpl implements TokenInstanceService {
             token.setCode(tokenCode);
 
             tokenInstanceRepository.save(token);
+            keyStoreCacheService.evictAfterCommit(uuid);
         }
     }
 
@@ -196,6 +195,7 @@ public class TokenInstanceServiceImpl implements TokenInstanceService {
         } else {
             token.setCode(null);
             tokenInstanceRepository.save(token);
+            keyStoreCacheService.evictAfterCommit(uuid);
         }
     }
 
@@ -207,6 +207,7 @@ public class TokenInstanceServiceImpl implements TokenInstanceService {
     @Override
     public void saveTokenInstance(TokenInstance tokenInstance) {
         tokenInstanceRepository.save(tokenInstance);
+        keyStoreCacheService.evictAfterCommit(tokenInstance.getUuid());
     }
 
     private MetadataAttribute buildNameMetadata(String name) {
@@ -232,4 +233,13 @@ public class TokenInstanceServiceImpl implements TokenInstanceService {
         return metadataAttribute;
     }
 
+    @Autowired
+    public void setTokenInstanceRepository(TokenInstanceRepository tokenInstanceRepository) {
+        this.tokenInstanceRepository = tokenInstanceRepository;
+    }
+
+    @Autowired
+    public void setKeyStoreCacheService(KeyStoreCacheService keyStoreCacheService) {
+        this.keyStoreCacheService = keyStoreCacheService;
+    }
 }

--- a/src/main/java/com/czertainly/cp/soft/util/CipherUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/CipherUtil.java
@@ -14,8 +14,9 @@ import com.czertainly.api.model.connector.cryptography.operations.data.CipherRes
 import com.czertainly.api.model.common.enums.cryptography.RsaEncryptionScheme;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.cp.soft.attribute.RsaCipherAttributes;
-import com.czertainly.cp.soft.dao.entity.KeyData;
 import com.czertainly.cp.soft.exception.NotSupportedException;
+import com.czertainly.cp.soft.model.CachedKeyData;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import javax.crypto.BadPaddingException;
@@ -38,42 +39,42 @@ public class CipherUtil {
      */
     private record CipherSpec(String transformation, AlgorithmParameterSpec parameterSpec) {}
 
-    public static DecryptDataResponseDto decrypt(CipherDataRequestDto request, KeyData key) {
-        switch (key.getAlgorithm()) {
+    public static DecryptDataResponseDto decrypt(CipherDataRequestDto request, CachedKeyData key, CachedKeyMaterial material) {
+        switch (key.algorithm()) {
             case RSA -> {
                 List<RequestAttribute> attributes = request.getCipherAttributes();
                 RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
-                return decryptData(request, key, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
+                return decryptData(request, key, material, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
             }
             default -> throw new NotSupportedException("Algorithm not supported");
         }
     }
 
-    public static EncryptDataResponseDto encrypt(CipherDataRequestDto request, KeyData key) {
-        switch (key.getAlgorithm()) {
+    public static EncryptDataResponseDto encrypt(CipherDataRequestDto request, CachedKeyData key, CachedKeyMaterial material) {
+        switch (key.algorithm()) {
             case RSA -> {
                 List<RequestAttribute> attributes = request.getCipherAttributes();
                 RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
-                return encryptData(request, key, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
+                return encryptData(request, key, material, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
             }
             default -> throw new NotSupportedException("Algorithm not supported");
         }
     }
 
-    private static DecryptDataResponseDto decryptData(CipherDataRequestDto request, KeyData key, CipherSpec cipherSpec) {
+    private static DecryptDataResponseDto decryptData(CipherDataRequestDto request, CachedKeyData key, CachedKeyMaterial material, CipherSpec cipherSpec) {
         DecryptDataResponseDto responseDto = new DecryptDataResponseDto();
-        responseDto.setDecryptedData(doProcess(request.getCipherData(), Cipher.DECRYPT_MODE, cipherSpec, key));
+        responseDto.setDecryptedData(doProcess(request.getCipherData(), Cipher.DECRYPT_MODE, cipherSpec, key, material));
         return responseDto;
     }
 
-    private static EncryptDataResponseDto encryptData(CipherDataRequestDto request, KeyData key, CipherSpec cipherSpec) {
+    private static EncryptDataResponseDto encryptData(CipherDataRequestDto request, CachedKeyData key, CachedKeyMaterial material, CipherSpec cipherSpec) {
         EncryptDataResponseDto responseDto = new EncryptDataResponseDto();
-        responseDto.setEncryptedData(doProcess(request.getCipherData(), Cipher.ENCRYPT_MODE, cipherSpec, key));
+        responseDto.setEncryptedData(doProcess(request.getCipherData(), Cipher.ENCRYPT_MODE, cipherSpec, key, material));
         return responseDto;
     }
 
     private static List<CipherResponseData> doProcess(List<CipherRequestData> cipherData, int mode,
-                                                      CipherSpec cipherSpec, KeyData key) {
+                                                      CipherSpec cipherSpec, CachedKeyData key, CachedKeyMaterial material) {
         Iterator<CipherRequestData> it = cipherData.stream().iterator();
         List<CipherResponseData> responseDataList = new ArrayList<>();
         while (it.hasNext()) {
@@ -82,8 +83,8 @@ public class CipherUtil {
                 Cipher cipher = Cipher.getInstance(cipherSpec.transformation(), BouncyCastleProvider.PROVIDER_NAME);
                 // RSA encryption must use the public key; decryption must use the private key.
                 Key cryptoKey = (mode == Cipher.ENCRYPT_MODE)
-                        ? KeyStoreUtil.getCertificate(key).getPublicKey()
-                        : KeyStoreUtil.getPrivateKey(key);
+                        ? KeyStoreUtil.getPublicKey(key, material)
+                        : KeyStoreUtil.getPrivateKey(key, material);
                 if (cipherSpec.parameterSpec() != null) {
                     cipher.init(mode, cryptoKey, cipherSpec.parameterSpec());
                 } else {

--- a/src/main/java/com/czertainly/cp/soft/util/CipherUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/CipherUtil.java
@@ -6,6 +6,7 @@ import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.common.attribute.v2.content.BooleanAttributeContentV2;
 import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
 import com.czertainly.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
 import com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto;
 import com.czertainly.api.model.connector.cryptography.operations.DecryptDataResponseDto;
 import com.czertainly.api.model.connector.cryptography.operations.EncryptDataResponseDto;
@@ -40,24 +41,22 @@ public class CipherUtil {
     private record CipherSpec(String transformation, AlgorithmParameterSpec parameterSpec) {}
 
     public static DecryptDataResponseDto decrypt(CipherDataRequestDto request, CachedKeyData key, CachedKeyMaterial material) {
-        switch (key.algorithm()) {
-            case RSA -> {
-                List<RequestAttribute> attributes = request.getCipherAttributes();
-                RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
-                return decryptData(request, key, material, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
-            }
-            default -> throw new NotSupportedException("Algorithm not supported");
+        if (key.algorithm() == KeyAlgorithm.RSA) {
+            List<RequestAttribute> attributes = request.getCipherAttributes();
+            RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
+            return decryptData(request, key, material, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
+        } else {
+            throw new NotSupportedException("Algorithm not supported");
         }
     }
 
     public static EncryptDataResponseDto encrypt(CipherDataRequestDto request, CachedKeyData key, CachedKeyMaterial material) {
-        switch (key.algorithm()) {
-            case RSA -> {
-                List<RequestAttribute> attributes = request.getCipherAttributes();
-                RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
-                return encryptData(request, key, material, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
-            }
-            default -> throw new NotSupportedException("Algorithm not supported");
+        if (key.algorithm() == KeyAlgorithm.RSA) {
+            List<RequestAttribute> attributes = request.getCipherAttributes();
+            RsaEncryptionScheme rsaEncryptionScheme = RsaEncryptionScheme.findByCode(AttributeDefinitionUtils.getSingleItemAttributeContentValue(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME, attributes, StringAttributeContentV2.class).getData());
+            return encryptData(request, key, material, getCipherSpec(rsaEncryptionScheme, request.getCipherAttributes()));
+        } else {
+            throw new NotSupportedException("Algorithm not supported");
         }
     }
 

--- a/src/main/java/com/czertainly/cp/soft/util/KeyStoreUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/KeyStoreUtil.java
@@ -2,8 +2,8 @@ package com.czertainly.cp.soft.util;
 
 import com.czertainly.api.model.connector.cryptography.key.value.SpkiKeyValue;
 import com.czertainly.cp.soft.collection.*;
-import com.czertainly.cp.soft.dao.entity.KeyData;
-import com.czertainly.cp.soft.exception.TokenInstanceException;
+import com.czertainly.cp.soft.model.CachedKeyData;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
 import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
 import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
@@ -293,28 +293,30 @@ public class KeyStoreUtil {
         }
     }
 
-    public static PrivateKey getPrivateKey(KeyData key) {
-        try {
-            if (key.getTokenInstance().getCode() == null) throw new TokenInstanceException("Token is not activated.");
-            KeyStore keyStore = loadKeystore(key.getTokenInstance().getData(), key.getTokenInstance().getCode());
-            return (PrivateKey) keyStore.getKey(key.getName(), key.getTokenInstance().getCode().toCharArray());
-        } catch (KeyStoreException e) {
-            throw new IllegalStateException("Cannot load Token '" + key.getTokenInstance().getName() + "'", e);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Algorithm '" + key.getAlgorithm() + "' cannot be used", e);
-        } catch (UnrecoverableKeyException e) {
-            throw new IllegalStateException("Cannot load private key '" + key.getName() + "' from Token '" + key.getTokenInstance().getName() + "'", e);
+    /**
+     * Returns the private key from cached key material. Use on the crypto operation hot path.
+     */
+    public static PrivateKey getPrivateKey(CachedKeyData key, CachedKeyMaterial material) {
+        PrivateKey pk = material.privateKeys().get(key.alias());
+        if (pk == null) {
+            throw new IllegalStateException(
+                    "No private key for alias '" + key.alias()
+                    + "' in cached material for token " + key.tokenInstanceUuid());
         }
+        return pk;
     }
 
-    public static X509Certificate getCertificate(KeyData key) {
-        if (key.getTokenInstance().getCode() == null) throw new TokenInstanceException("Token is not activated.");
-        KeyStore keyStore = loadKeystore(key.getTokenInstance().getData(), key.getTokenInstance().getCode());
-        try {
-            return (X509Certificate) keyStore.getCertificate(key.getName());
-        } catch (KeyStoreException e) {
-            throw new IllegalStateException("Cannot load Token '" + key.getTokenInstance().getName() + "'", e);
+    /**
+     * Returns the public key from cached key material. Use on the crypto operation hot path.
+     */
+    public static PublicKey getPublicKey(CachedKeyData key, CachedKeyMaterial material) {
+        PublicKey pub = material.publicKeys().get(key.alias());
+        if (pub == null) {
+            throw new IllegalStateException(
+                    "No public key for alias '" + key.alias()
+                    + "' in cached material for token " + key.tokenInstanceUuid());
         }
+        return pub;
     }
 
 }

--- a/src/main/java/com/czertainly/cp/soft/util/KeyStoreUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/KeyStoreUtil.java
@@ -2,6 +2,7 @@ package com.czertainly.cp.soft.util;
 
 import com.czertainly.api.model.connector.cryptography.key.value.SpkiKeyValue;
 import com.czertainly.cp.soft.collection.*;
+import com.czertainly.cp.soft.exception.CryptographicOperationException;
 import com.czertainly.cp.soft.model.CachedKeyData;
 import com.czertainly.cp.soft.model.CachedKeyMaterial;
 import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey;
@@ -299,7 +300,7 @@ public class KeyStoreUtil {
     public static PrivateKey getPrivateKey(CachedKeyData key, CachedKeyMaterial material) {
         PrivateKey pk = material.privateKeys().get(key.alias());
         if (pk == null) {
-            throw new IllegalStateException(
+            throw new CryptographicOperationException(
                     "No private key for alias '" + key.alias()
                     + "' in cached material for token " + key.tokenInstanceUuid());
         }
@@ -312,7 +313,7 @@ public class KeyStoreUtil {
     public static PublicKey getPublicKey(CachedKeyData key, CachedKeyMaterial material) {
         PublicKey pub = material.publicKeys().get(key.alias());
         if (pub == null) {
-            throw new IllegalStateException(
+            throw new CryptographicOperationException(
                     "No public key for alias '" + key.alias()
                     + "' in cached material for token " + key.tokenInstanceUuid());
         }

--- a/src/main/java/com/czertainly/cp/soft/util/SignatureUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/SignatureUtil.java
@@ -10,9 +10,10 @@ import com.czertainly.api.model.connector.cryptography.key.value.SpkiKeyValue;
 import com.czertainly.core.util.AttributeDefinitionUtils;
 import com.czertainly.cp.soft.attribute.EcdsaKeyAttributes;
 import com.czertainly.cp.soft.attribute.RsaKeyAttributes;
-import com.czertainly.cp.soft.dao.entity.KeyData;
 import com.czertainly.cp.soft.exception.CryptographicOperationException;
 import com.czertainly.cp.soft.exception.NotSupportedException;
+import com.czertainly.cp.soft.model.CachedKeyData;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPublicKey;
 import org.bouncycastle.jcajce.provider.asymmetric.slhdsa.BCSLHDSAPublicKey;
@@ -26,19 +27,19 @@ import java.util.List;
 
 public class SignatureUtil {
 
-    public static Signature prepareSignature(KeyData key, List<RequestAttribute> signatureAttributes) {
+    public static Signature prepareSignature(CachedKeyData key, List<RequestAttribute> signatureAttributes) {
         String signatureAlgorithm;
 
-        switch (key.getAlgorithm()) {
+        switch (key.algorithm()) {
             case RSA -> {
                 final RsaSignatureScheme scheme = RsaSignatureScheme.findByCode(
                         AttributeDefinitionUtils.getSingleItemAttributeContentValue(
-                                RsaKeyAttributes.ATTRIBUTE_DATA_RSA_SIG_SCHEME, signatureAttributes, StringAttributeContentV2.class)
+                                        RsaKeyAttributes.ATTRIBUTE_DATA_RSA_SIG_SCHEME, signatureAttributes, StringAttributeContentV2.class)
                                 .getData()
                 );
                 final DigestAlgorithm digest = DigestAlgorithm.findByCode(
                         AttributeDefinitionUtils.getSingleItemAttributeContentValue(
-                                RsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST, signatureAttributes, StringAttributeContentV2.class)
+                                        RsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST, signatureAttributes, StringAttributeContentV2.class)
                                 .getData()
                 );
 
@@ -52,7 +53,7 @@ public class SignatureUtil {
             case ECDSA -> {
                 final DigestAlgorithm digest = DigestAlgorithm.findByCode(
                         AttributeDefinitionUtils.getSingleItemAttributeContentValue(
-                                EcdsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST, signatureAttributes, StringAttributeContentV2.class)
+                                        EcdsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST, signatureAttributes, StringAttributeContentV2.class)
                                 .getData()
                 );
 
@@ -73,10 +74,10 @@ public class SignatureUtil {
             case MLDSA -> {
                 signatureAlgorithm = "";
                 boolean usePrehash = false;
-                if (key.getType() == KeyType.PRIVATE_KEY) {
-                    usePrehash = ((CustomKeyValue) key.getValue()).getValues().get("prehash").equals(String.valueOf(true));
+                if (key.type() == KeyType.PRIVATE_KEY) {
+                    usePrehash = ((CustomKeyValue) key.value()).getValues().get("prehash").equals(String.valueOf(true));
                 } else {
-                    SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.getValue();
+                    SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.value();
                     BCMLDSAPublicKey bcmldsaPublicKey;
                     try {
                         bcmldsaPublicKey = new BCMLDSAPublicKey(
@@ -98,10 +99,10 @@ public class SignatureUtil {
             case SLHDSA -> {
                 signatureAlgorithm = "";
                 boolean usePrehash = false;
-                if (key.getType() == KeyType.PRIVATE_KEY) {
-                    usePrehash = ((CustomKeyValue) key.getValue()).getValues().get("prehash").equals(String.valueOf(true));
+                if (key.type() == KeyType.PRIVATE_KEY) {
+                    usePrehash = ((CustomKeyValue) key.value()).getValues().get("prehash").equals(String.valueOf(true));
                 } else {
-                    SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.getValue();
+                    SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.value();
                     BCSLHDSAPublicKey bcslhdsaPublicKey;
                     try {
                         bcslhdsaPublicKey = new BCSLHDSAPublicKey(
@@ -134,19 +135,19 @@ public class SignatureUtil {
         }
     }
 
-    public static void initSigning(Signature signature, KeyData key) {
+    public static void initSigning(Signature signature, CachedKeyData key, CachedKeyMaterial material) {
         try {
-            signature.initSign(KeyStoreUtil.getPrivateKey(key));
+            signature.initSign(KeyStoreUtil.getPrivateKey(key, material));
         } catch (InvalidKeyException e) {
-            throw new IllegalStateException("Invalid key '"+key.getName()+"'", e);
+            throw new IllegalStateException("Invalid key '" + key.alias() + "'", e);
         }
     }
 
-    public static void initVerification(Signature signature, KeyData key) {
+    public static void initVerification(Signature signature, CachedKeyData key, CachedKeyMaterial material) {
         try {
-            signature.initVerify(KeyStoreUtil.getCertificate(key));
+            signature.initVerify(KeyStoreUtil.getPublicKey(key, material));
         } catch (InvalidKeyException e) {
-            throw new IllegalStateException("Invalid key '" + key.getName() + "'", e);
+            throw new IllegalStateException("Invalid key '" + key.alias() + "'", e);
         }
     }
 

--- a/src/main/java/com/czertainly/cp/soft/util/SignatureUtil.java
+++ b/src/main/java/com/czertainly/cp/soft/util/SignatureUtil.java
@@ -72,56 +72,44 @@ public class SignatureUtil {
                 */
             }
             case MLDSA -> {
-                signatureAlgorithm = "";
-                boolean usePrehash = false;
-                if (key.type() == KeyType.PRIVATE_KEY) {
-                    usePrehash = ((CustomKeyValue) key.value()).getValues().get("prehash").equals(String.valueOf(true));
-                } else {
-                    SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.value();
-                    BCMLDSAPublicKey bcmldsaPublicKey;
-                    try {
-                        bcmldsaPublicKey = new BCMLDSAPublicKey(
-                                SubjectPublicKeyInfo.getInstance(
-                                        Base64.getDecoder().decode(
-                                                spkiKeyValue.getValue()
-                                        )
-                                ));
-                    } catch (IOException e) {
-                        throw new CryptographicOperationException("Could not create BCMLDSAPublicKey instance from ML-DSA Public Key value: " + spkiKeyValue.getValue());
-                    }
-                    if (bcmldsaPublicKey.getParameterSpec().getName().contains("WITH")) usePrehash = true;
-                }
-                if (usePrehash) signatureAlgorithm += "HASH-";
-                signatureAlgorithm += "ML-DSA";
-
+                signatureAlgorithm = (isMlDsaPrehash(key) ? "HASH-" : "") + "ML-DSA";
                 return getInstanceSignature(signatureAlgorithm, BouncyCastleProvider.PROVIDER_NAME);
             }
             case SLHDSA -> {
-                signatureAlgorithm = "";
-                boolean usePrehash = false;
-                if (key.type() == KeyType.PRIVATE_KEY) {
-                    usePrehash = ((CustomKeyValue) key.value()).getValues().get("prehash").equals(String.valueOf(true));
-                } else {
-                    SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.value();
-                    BCSLHDSAPublicKey bcslhdsaPublicKey;
-                    try {
-                        bcslhdsaPublicKey = new BCSLHDSAPublicKey(
-                                SubjectPublicKeyInfo.getInstance(
-                                        Base64.getDecoder().decode(
-                                                spkiKeyValue.getValue()
-                                        )
-                                ));
-                    } catch (IOException e) {
-                        throw new CryptographicOperationException("Could not create BCSLHDSAPublicKey instance from SLH-DSA Public Key value: " + spkiKeyValue.getValue());
-                    }
-                    if (bcslhdsaPublicKey.getParameterSpec().getName().contains("WITH")) usePrehash = true;
-                }
-                if (usePrehash) signatureAlgorithm += "HASH-";
-                signatureAlgorithm += "SLH-DSA";
-
+                signatureAlgorithm = (isSlhDsaPrehash(key) ? "HASH-" : "") + "SLH-DSA";
                 return getInstanceSignature(signatureAlgorithm, BouncyCastleProvider.PROVIDER_NAME);
             }
             default -> throw new NotSupportedException("Cryptographic algorithm not supported");
+        }
+    }
+
+    private static boolean isMlDsaPrehash(CachedKeyData key) {
+        if (key.type() == KeyType.PRIVATE_KEY) {
+            return ((CustomKeyValue) key.value()).getValues().get("prehash").equals(String.valueOf(true));
+        }
+        SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.value();
+        try {
+            BCMLDSAPublicKey pk = new BCMLDSAPublicKey(
+                    SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(spkiKeyValue.getValue())));
+            return pk.getParameterSpec().getName().contains("WITH");
+        } catch (IOException e) {
+            throw new CryptographicOperationException(
+                    "Could not create BCMLDSAPublicKey instance from ML-DSA Public Key value: " + spkiKeyValue.getValue());
+        }
+    }
+
+    private static boolean isSlhDsaPrehash(CachedKeyData key) {
+        if (key.type() == KeyType.PRIVATE_KEY) {
+            return ((CustomKeyValue) key.value()).getValues().get("prehash").equals(String.valueOf(true));
+        }
+        SpkiKeyValue spkiKeyValue = (SpkiKeyValue) key.value();
+        try {
+            BCSLHDSAPublicKey pk = new BCSLHDSAPublicKey(
+                    SubjectPublicKeyInfo.getInstance(Base64.getDecoder().decode(spkiKeyValue.getValue())));
+            return pk.getParameterSpec().getName().contains("WITH");
+        } catch (IOException e) {
+            throw new CryptographicOperationException(
+                    "Could not create BCSLHDSAPublicKey instance from SLH-DSA Public Key value: " + spkiKeyValue.getValue());
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,8 @@ spring:
     schemas: ${DB_SCHEMA:softcp}
   jpa:
     properties:
-      hibernate.default_schema: ${DB_SCHEMA:softcp}
+      hibernate:
+        default_schema: ${DB_SCHEMA:softcp}
 
 management:
   endpoints:
@@ -35,3 +36,22 @@ secrets:
 
 token:
   deleteOnRemove: ${TOKEN_DELETE_ON_REMOVE:false}
+
+provider:
+  cache:
+    # Caffeine cache for decrypted key material loaded from token-instance keystores.
+    # Each entry holds the raw key bytes for one token instance UUID.
+    keystore:
+      # How long (in seconds) a keystore entry remains valid after it was last written.
+      # After expiry, the next access reloads the keystore from the database.
+      ttl-seconds: 60
+      # Maximum number of token-instance keystores kept in memory simultaneously.
+      max-size: 500
+    # Caffeine cache for CachedKeyData DTOs read from the key_data table.
+    # Each entry corresponds to one key UUID.
+    keydata:
+      # How long (in seconds) a key-data entry remains valid after it was last written.
+      # After expiry, the next access reloads the row from the database.
+      ttl-seconds: 300
+      # Maximum number of key-data entries kept in memory simultaneously.
+      max-size: 10000

--- a/src/test/java/com/czertainly/cp/soft/ExceptionHandlingAdviceTest.java
+++ b/src/test/java/com/czertainly/cp/soft/ExceptionHandlingAdviceTest.java
@@ -1,0 +1,29 @@
+package com.czertainly.cp.soft;
+
+import com.czertainly.cp.soft.dto.ApiErrorResponseDto;
+import com.czertainly.cp.soft.exception.CryptographicOperationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExceptionHandlingAdviceTest {
+
+    private final ExceptionHandlingAdvice advice = new ExceptionHandlingAdvice();
+
+    @Test
+    void handleCryptographicOperationException_returns400WithErrorCode702() {
+        CryptographicOperationException ex = new CryptographicOperationException("signing failed");
+
+        ResponseEntity<Object> response = advice.handleCryptographicOperationException(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ApiErrorResponseDto body = (ApiErrorResponseDto) response.getBody();
+        assertNotNull(body);
+        assertEquals(702, body.getCode());
+        assertEquals("Cryptographic operation problem", body.getMessage());
+        assertFalse(body.getErrors().isEmpty());
+        assertEquals("signing failed", body.getErrors().get(0).getError());
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/model/CachedKeyMaterialConcurrencyTest.java
+++ b/src/test/java/com/czertainly/cp/soft/model/CachedKeyMaterialConcurrencyTest.java
@@ -1,0 +1,188 @@
+package com.czertainly.cp.soft.model;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jcajce.spec.MLDSAParameterSpec;
+import org.bouncycastle.jcajce.spec.SLHDSAParameterSpec;
+import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
+import org.bouncycastle.pqc.jcajce.spec.FalconParameterSpec;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.spec.ECGenParameterSpec;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression guard for the thread-safety claim in {@link CachedKeyMaterial} which states that the BouncyCastle
+ * {@link PrivateKey} implementations stored in the record ({@code BCRSAPrivateCrtKey}, {@code BCECPrivateKey},
+ * {@code BCFalconPrivateKey}, {@code BCMLDSAPrivateKey}, {@code BCSLHDSAPrivateKey}) are
+ * immutable and therefore safe for concurrent reads without synchronization.
+ *
+ * <p><b>Design:</b>
+ * <ul>
+ *   <li>A pool of {@value #N_COLD_KEYS} fresh key pairs is pre-generated per algorithm so that each round races
+ *   on a key whose potential lazy state has <em>never</em> been touched by a prior {@code initSign} call.</li>
+ *   <li>{@value #THREAD_COUNT} virtual threads each create their own {@link Signature} instance (which is not thread-safe)
+ *   and synchronize on a {@link java.util.concurrent.CyclicBarrier} placed immediately before {@link Signature#initSign}
+ *   so that all first-touches of the shared key object happen at the same instant.</li>
+ *   <li>Every signature produced by every thread is verified with the corresponding public key.</li>
+ *   <li>The key is always fetched through {@link CachedKeyMaterial#privateKeys()} to exercise the actual production code path.</li>
+ * </ul>
+ */
+class CachedKeyMaterialConcurrencyTest {
+
+    /**
+     * Number of threads racing simultaneously on each shared key instance.
+     */
+    private static final int THREAD_COUNT = 16;
+
+    /**
+     * Number of fresh key pairs per algorithm. Each round uses a distinct key pair so that the
+     * first-touch race is repeated with a key that has never had {@code initSign} called on it.
+     */
+    private static final int N_COLD_KEYS = 8;
+
+    /**
+     * Fewer rounds for SLH-DSA because signing is more expensive for that algorithm family.
+     */
+    private static final int N_COLD_KEYS_SLHDSA = 3;
+
+    private static final byte[] DATA = "Regression probe — CachedKeyMaterial thread-safety".getBytes(StandardCharsets.UTF_8);
+
+    private static final List<KeyPair> RSA_POOL;
+    private static final List<KeyPair> EC_POOL;
+    private static final List<KeyPair> FALCON_POOL;
+    private static final List<KeyPair> MLDSA_POOL;
+    private static final List<KeyPair> SLHDSA_POOL;
+
+    static {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        if (Security.getProvider(BouncyCastlePQCProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastlePQCProvider());
+        }
+        try {
+            KeyPairGenerator kpg;
+
+            kpg = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
+            kpg.initialize(2048);
+            RSA_POOL = generateKeyPairs(kpg, N_COLD_KEYS);
+
+            kpg = KeyPairGenerator.getInstance("ECDSA", BouncyCastleProvider.PROVIDER_NAME);
+            kpg.initialize(new ECGenParameterSpec("secp256r1"));
+            EC_POOL = generateKeyPairs(kpg, N_COLD_KEYS);
+
+            kpg = KeyPairGenerator.getInstance("Falcon", BouncyCastlePQCProvider.PROVIDER_NAME);
+            kpg.initialize(FalconParameterSpec.falcon_512);
+            FALCON_POOL = generateKeyPairs(kpg, N_COLD_KEYS);
+
+            kpg = KeyPairGenerator.getInstance("ML-DSA", BouncyCastleProvider.PROVIDER_NAME);
+            kpg.initialize(MLDSAParameterSpec.fromName("ML-DSA-44"));
+            MLDSA_POOL = generateKeyPairs(kpg, N_COLD_KEYS);
+
+            kpg = KeyPairGenerator.getInstance("SLH-DSA", BouncyCastleProvider.PROVIDER_NAME);
+            kpg.initialize(SLHDSAParameterSpec.fromName("SLH-DSA-SHA2-128f"));
+            SLHDSA_POOL = generateKeyPairs(kpg, N_COLD_KEYS_SLHDSA);
+
+        } catch (Exception e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static List<KeyPair> generateKeyPairs(KeyPairGenerator kpg, int count) {
+        List<KeyPair> pool = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            pool.add(kpg.generateKeyPair());
+        }
+        return Collections.unmodifiableList(pool);
+    }
+
+    static Stream<Arguments> keyFixtures() {
+        return Stream.of(
+                Arguments.of("BCRSAPrivateCrtKey (RSA-2048)",
+                        RSA_POOL, "SHA256withRSA", BouncyCastleProvider.PROVIDER_NAME),
+                Arguments.of("BCECPrivateKey (ECDSA secp256r1)",
+                        EC_POOL, "SHA256withECDSA", BouncyCastleProvider.PROVIDER_NAME),
+                Arguments.of("BCFalconPrivateKey (Falcon-512)",
+                        FALCON_POOL, "FALCON", BouncyCastlePQCProvider.PROVIDER_NAME),
+                Arguments.of("BCMLDSAPrivateKey (ML-DSA-44)",
+                        MLDSA_POOL, "ML-DSA", BouncyCastleProvider.PROVIDER_NAME),
+                Arguments.of("BCSLHDSAPrivateKey (SLH-DSA-SHA2-128f)",
+                        SLHDSA_POOL, "SLH-DSA", BouncyCastleProvider.PROVIDER_NAME)
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("keyFixtures")
+    void concurrentInitSign_sharedKeyRemainsIncorruptible(String label,
+                                                          List<KeyPair> keyPool,
+                                                          String algorithm,
+                                                          String provider) throws Exception {
+
+        for (KeyPair freshPair : keyPool) {
+            // The CachedKeyMaterial wrapping a cold key pair — this is the object every thread reads from.
+            CachedKeyMaterial material = new CachedKeyMaterial(
+                    Collections.singletonMap("key", freshPair.getPrivate()),
+                    Collections.singletonMap("key", freshPair.getPublic()));
+
+            // Barrier placed *before* initSign so all threads touch the shared key at the same instant.
+            java.util.concurrent.CyclicBarrier startGate =
+                    new java.util.concurrent.CyclicBarrier(THREAD_COUNT);
+
+            List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+            byte[][] signatures = new byte[THREAD_COUNT][];
+
+            List<Thread> threads = new ArrayList<>(THREAD_COUNT);
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int idx = t;
+                threads.add(Thread.ofVirtual().start(() -> {
+                    try {
+                        // Signature is NOT thread-safe — each thread owns its own instance.
+                        // Create it before the barrier so setup cost is not inside the race window.
+                        Signature sig = Signature.getInstance(algorithm, provider);
+                        startGate.await(); // synchronize: all threads hit initSign at once
+                        sig.initSign(material.privateKeys().get("key"));
+                        sig.update(DATA);
+                        signatures[idx] = sig.sign();
+                    } catch (Throwable e) {
+                        errors.add(e);
+                    }
+                }));
+            }
+
+            for (Thread t : threads) {
+                t.join();
+            }
+
+            if (!errors.isEmpty()) {
+                AssertionError failure = new AssertionError(
+                        "Concurrent Signature.initSign raised " + errors.size()
+                                + " exception(s) for " + label + ". The BC key class likely has mutable "
+                                + "lazy-cached state — re-evaluate the thread-safety claim in CachedKeyMaterial.");
+                errors.forEach(failure::addSuppressed);
+                throw failure;
+            }
+
+            // Every thread must have produced a verifiably correct signature.
+            // Checking only the final iteration would miss transient corruption.
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                assertNotNull(signatures[t],
+                        "Thread " + t + " produced a null signature for " + label);
+                Signature verifier = Signature.getInstance(algorithm, provider);
+                verifier.initVerify(freshPair.getPublic());
+                verifier.update(DATA);
+                assertTrue(verifier.verify(signatures[t]),
+                        "Thread " + t + " produced an invalid signature for " + label
+                                + " — possible silent state corruption in the shared key instance");
+            }
+        }
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CacheInvalidationTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CacheInvalidationTest.java
@@ -3,6 +3,7 @@ package com.czertainly.cp.soft.service.impl;
 import com.czertainly.api.exception.NotFoundException;
 import com.czertainly.api.model.client.attribute.RequestAttribute;
 import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.cp.soft.exception.TokenInstanceException;
 import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
 import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
 import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
@@ -166,6 +167,72 @@ class CacheInvalidationTest {
 
         // The cache must remain empty for this key (exception was not cached)
         assertCacheMiss(CacheConfig.KEYSTORES_CACHE, nonExistentUuid);
+    }
+
+    // -----------------------------------------------------------------------
+    // evictAfterCommit — outside-transaction path
+    // -----------------------------------------------------------------------
+
+    /**
+     * When {@code evictAfterCommit} is called with no active transaction, it must evict immediately
+     * rather than scheduling a post-commit callback.
+     */
+    @Test
+    void keystoreEvictAfterCommit_outsideTransaction_evictsImmediately() throws NotFoundException {
+        UUID tokenUuid = tokenInstance.getUuid();
+
+        // Warm the cache
+        keyStoreCacheService.loadKeyMaterial(tokenUuid);
+        assertCacheHit(CacheConfig.KEYSTORES_CACHE, tokenUuid);
+
+        // Called directly from a non-transactional test method — takes the else (immediate) branch
+        keyStoreCacheService.evictAfterCommit(tokenUuid);
+
+        assertCacheMiss(CacheConfig.KEYSTORES_CACHE, tokenUuid);
+    }
+
+    /**
+     * Same immediate-eviction guarantee for the keydata cache.
+     */
+    @Test
+    void keydataEvictAfterCommit_outsideTransaction_evictsImmediately() throws NotFoundException {
+        UUID tokenUuid = tokenInstance.getUuid();
+
+        KeyPairDataResponseDto created = keyManagementService.createKeyPair(tokenUuid, buildRsa2048Request("kd-outside-tx"));
+        UUID privateKeyUuid = UUID.fromString(created.getPrivateKeyData().getUuid());
+
+        // Warm the keydata cache
+        keyDataCacheService.getCachedKeyData(privateKeyUuid);
+        assertCacheHit(CacheConfig.KEYDATA_CACHE, privateKeyUuid);
+
+        // Called directly from a non-transactional test method — takes the else (immediate) branch
+        keyDataCacheService.evictAfterCommit(privateKeyUuid);
+
+        assertCacheMiss(CacheConfig.KEYDATA_CACHE, privateKeyUuid);
+    }
+
+    // -----------------------------------------------------------------------
+    // loadKeyMaterial — token not activated
+    // -----------------------------------------------------------------------
+
+    /**
+     * Loading key material for a token whose activation code is null must throw
+     * {@link TokenInstanceException} and must not populate the cache.
+     */
+    @Test
+    void loadKeyMaterial_tokenNotActivated_throwsTokenInstanceException() {
+        TokenInstance inactiveToken = new TokenInstance();
+        inactiveToken.setCode(null);
+        inactiveToken.setData(KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD));
+        tokenInstanceRepository.save(inactiveToken);
+
+        UUID inactiveUuid = inactiveToken.getUuid();
+
+        assertThrows(TokenInstanceException.class,
+                () -> keyStoreCacheService.loadKeyMaterial(inactiveUuid));
+
+        // Exception must not have been cached
+        assertCacheMiss(CacheConfig.KEYSTORES_CACHE, inactiveUuid);
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CacheInvalidationTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CacheInvalidationTest.java
@@ -1,0 +1,217 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.cp.soft.attribute.KeyAttributes;
+import com.czertainly.cp.soft.attribute.RsaKeyAttributes;
+import com.czertainly.cp.soft.config.CacheConfig;
+import com.czertainly.cp.soft.dao.entity.TokenInstance;
+import com.czertainly.cp.soft.dao.repository.KeyDataRepository;
+import com.czertainly.cp.soft.dao.repository.TokenInstanceRepository;
+import com.czertainly.cp.soft.service.KeyDataCacheService;
+import com.czertainly.cp.soft.service.KeyManagementService;
+import com.czertainly.cp.soft.service.KeyStoreCacheService;
+import com.czertainly.cp.soft.service.TokenInstanceService;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies cache-invalidation semantics for the {@code keystores} and {@code keydata} caches.
+ *
+ * <p>This class is intentionally <strong>not</strong> annotated with {@code @Transactional}.
+ */
+@SpringBootTest
+class CacheInvalidationTest {
+
+    private static final String PASSWORD    = "123";
+    private static final int    RSA_KEY_SIZE = 2048;
+
+    @Autowired private KeyManagementService    keyManagementService;
+    @Autowired private KeyStoreCacheService    keyStoreCacheService;
+    @Autowired private KeyDataCacheService     keyDataCacheService;
+    @Autowired private TokenInstanceService    tokenInstanceService;
+    @Autowired private TokenInstanceRepository tokenInstanceRepository;
+    @Autowired private KeyDataRepository       keyDataRepository;
+    @Autowired private CacheManager            cacheManager;
+
+    private TokenInstance tokenInstance;
+
+    @BeforeEach
+    void setUp() {
+        tokenInstance = new TokenInstance();
+        tokenInstance.setCode(PASSWORD);
+        tokenInstance.setData(KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD));
+        // save() runs in its own committed transaction (no surrounding test transaction)
+        tokenInstanceRepository.save(tokenInstance);
+    }
+
+    @AfterEach
+    void tearDown() {
+        keyDataRepository.deleteAll();
+        tokenInstanceRepository.deleteAll();
+        Objects.requireNonNull(cacheManager.getCache(CacheConfig.KEYSTORES_CACHE)).clear();
+        Objects.requireNonNull(cacheManager.getCache(CacheConfig.KEYDATA_CACHE)).clear();
+    }
+
+    // -----------------------------------------------------------------------
+    // Keystore cache — eviction on destroyKey (private key path)
+    // -----------------------------------------------------------------------
+
+    /**
+     * After the private key is destroyed, the keystore cache entry for the owning token instance must be evicted
+     * so that the next access re-reads a consistent keystore from the database.
+     */
+    @Test
+    void destroyPrivateKey_shouldEvictKeystoreCache() throws NotFoundException {
+        UUID tokenUuid = tokenInstance.getUuid();
+
+        // Create key pair — commits; saveTokenInstance evicts the cache
+        KeyPairDataResponseDto created = keyManagementService.createKeyPair(tokenUuid, buildRsa2048Request("ks-evict"));
+        UUID privateKeyUuid = UUID.fromString(created.getPrivateKeyData().getUuid());
+
+        // Warm the keystore cache
+        keyStoreCacheService.loadKeyMaterial(tokenUuid);
+        assertCacheHit(CacheConfig.KEYSTORES_CACHE, tokenUuid);
+
+        // Destroy the private key — commits; removeKeyFromKeyStore → saveTokenInstance → evictAfterCommit
+        keyManagementService.destroyKey(tokenUuid, privateKeyUuid);
+
+        assertCacheMiss(CacheConfig.KEYSTORES_CACHE, tokenUuid);
+    }
+
+    // -----------------------------------------------------------------------
+    // Keystore cache — eviction on deactivateTokenInstance
+    // -----------------------------------------------------------------------
+
+    /**
+     * Deactivating a token instance nulls its activation code and must evict the keystore cache so that subsequent
+     * calls cannot use stale key material.
+     */
+    @Test
+    void deactivateTokenInstance_shouldEvictKeystoreCache() throws NotFoundException {
+        UUID tokenUuid = tokenInstance.getUuid();
+
+        // Warm the keystore cache
+        keyStoreCacheService.loadKeyMaterial(tokenUuid);
+        assertCacheHit(CacheConfig.KEYSTORES_CACHE, tokenUuid);
+
+        // Deactivate — commits; evictAfterCommit is scheduled inside deactivateTokenInstance
+        tokenInstanceService.deactivateTokenInstance(tokenUuid);
+
+        assertCacheMiss(CacheConfig.KEYSTORES_CACHE, tokenUuid);
+    }
+
+    // -----------------------------------------------------------------------
+    // Keydata cache — eviction on destroyKey
+    // -----------------------------------------------------------------------
+
+    /**
+     * After a key is destroyed, its keydata cache entry must be evicted so that a subsequent getCachedKeyData call hits
+     * the database and throws NotFoundException rather than serving a stale record.
+     */
+    @Test
+    void destroyKey_shouldEvictKeydataCache() throws NotFoundException {
+        UUID tokenUuid = tokenInstance.getUuid();
+
+        // Create key pair so we have a persisted private-key record
+        KeyPairDataResponseDto created = keyManagementService.createKeyPair(tokenUuid, buildRsa2048Request("kd-evict"));
+        UUID privateKeyUuid = UUID.fromString(created.getPrivateKeyData().getUuid());
+
+        // Warm the keydata cache for the private key
+        keyDataCacheService.getCachedKeyData(privateKeyUuid);
+        assertCacheHit(CacheConfig.KEYDATA_CACHE, privateKeyUuid);
+
+        // Destroy the private key — commits; keyDataCacheService.evictAfterCommit fires
+        keyManagementService.destroyKey(tokenUuid, privateKeyUuid);
+
+        assertCacheMiss(CacheConfig.KEYDATA_CACHE, privateKeyUuid);
+    }
+
+    // -----------------------------------------------------------------------
+    // NotFoundException must NOT be cached
+    // -----------------------------------------------------------------------
+
+    /**
+     * A {@link NotFoundException} thrown by {@code loadKeyMaterial} must not be cached.
+     */
+    @Test
+    void keystoreLoadMiss_notFoundExceptionIsNotCached() {
+        UUID nonExistentUuid = UUID.randomUUID();
+
+        // First call: no token instance in DB or cache — must throw
+        assertThrows(NotFoundException.class,
+                () -> keyStoreCacheService.loadKeyMaterial(nonExistentUuid));
+
+        // The cache must remain empty for this key (exception was not cached)
+        assertCacheMiss(CacheConfig.KEYSTORES_CACHE, nonExistentUuid);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private void assertCacheHit(String cacheName, UUID key) {
+        Cache springCache = Objects.requireNonNull(cacheManager.getCache(cacheName));
+        assertNotNull(springCache.get(key),
+                "Expected a cache HIT for key " + key + " in '" + cacheName + "' but found a miss");
+    }
+
+    private void assertCacheMiss(String cacheName, UUID key) {
+        Cache springCache = Objects.requireNonNull(cacheManager.getCache(cacheName));
+        assertNull(springCache.get(key),
+                "Expected a cache MISS for key " + key + " in '" + cacheName + "' but found an entry");
+    }
+
+    private CreateKeyRequestDto buildRsa2048Request(String alias) {
+        List<RequestAttribute> attrs = new ArrayList<>();
+
+        RequestAttributeV2 aliasAttr = new RequestAttributeV2();
+        aliasAttr.setName(KeyAttributes.ATTRIBUTE_DATA_KEY_ALIAS);
+        aliasAttr.setContentType(AttributeContentType.STRING);
+        aliasAttr.setContent(List.of(new StringAttributeContentV2(alias)));
+        attrs.add(aliasAttr);
+
+        RequestAttributeV2 algoAttr = new RequestAttributeV2();
+        algoAttr.setName(KeyAttributes.ATTRIBUTE_DATA_KEY_ALGORITHM);
+        algoAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 algoContent = new StringAttributeContentV2();
+        algoContent.setReference(KeyAlgorithm.RSA.getCode());
+        algoContent.setData(KeyAlgorithm.RSA.getCode());
+        algoAttr.setContent(List.of(algoContent));
+        attrs.add(algoAttr);
+
+        RequestAttributeV2 sizeAttr = new RequestAttributeV2();
+        sizeAttr.setName(RsaKeyAttributes.ATTRIBUTE_DATA_RSA_KEY_SIZE);
+        sizeAttr.setContentType(AttributeContentType.INTEGER);
+        IntegerAttributeContentV2 sizeContent = new IntegerAttributeContentV2();
+        sizeContent.setData(RSA_KEY_SIZE);
+        sizeAttr.setContent(List.of(sizeContent));
+        attrs.add(sizeAttr);
+
+        CreateKeyRequestDto req = new CreateKeyRequestDto();
+        req.setCreateKeyAttributes(attrs);
+        return req;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsTokenOwnershipTest.java
+++ b/src/test/java/com/czertainly/cp/soft/service/impl/CryptographicOperationsTokenOwnershipTest.java
@@ -1,0 +1,172 @@
+package com.czertainly.cp.soft.service.impl;
+
+import com.czertainly.api.exception.NotFoundException;
+import com.czertainly.api.model.client.attribute.RequestAttribute;
+import com.czertainly.api.model.client.attribute.RequestAttributeV2;
+import com.czertainly.api.model.common.attribute.common.content.AttributeContentType;
+import com.czertainly.api.model.common.attribute.v2.content.IntegerAttributeContentV2;
+import com.czertainly.api.model.common.attribute.v2.content.StringAttributeContentV2;
+import com.czertainly.api.model.common.enums.cryptography.DigestAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.RsaEncryptionScheme;
+import com.czertainly.api.model.common.enums.cryptography.RsaSignatureScheme;
+import com.czertainly.api.model.connector.cryptography.key.CreateKeyRequestDto;
+import com.czertainly.api.model.connector.cryptography.key.KeyPairDataResponseDto;
+import com.czertainly.api.model.connector.cryptography.operations.CipherDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.SignDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.VerifyDataRequestDto;
+import com.czertainly.api.model.connector.cryptography.operations.data.CipherRequestData;
+import com.czertainly.api.model.connector.cryptography.operations.data.SignatureRequestData;
+import com.czertainly.cp.soft.attribute.RsaCipherAttributes;
+import com.czertainly.cp.soft.attribute.RsaKeyAttributes;
+import com.czertainly.cp.soft.dao.entity.TokenInstance;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that cryptographic operations reject requests where the token instance UUID in the path
+ * does not match the token instance that owns the referenced key.
+ */
+@Transactional
+class CryptographicOperationsTokenOwnershipTest extends AbstractCryptographicOperationsTest {
+
+    private static final byte[] PLAINTEXT = "Hello, CZERTAINLY!".getBytes();
+
+    private TokenInstance otherTokenInstance;
+
+    @BeforeEach
+    void setUpOtherToken() {
+        otherTokenInstance = new TokenInstance();
+        otherTokenInstance.setCode(PASSWORD);
+        otherTokenInstance.setData(KeyStoreUtil.createNewKeystore("PKCS12", PASSWORD));
+        tokenInstanceRepository.save(otherTokenInstance);
+    }
+
+    @Test
+    void signData_withMismatchedTokenUuid_shouldThrowNotFoundException() throws NotFoundException {
+        KeyPairDataResponseDto pair = keyManagementService.createKeyPair(
+                tokenInstance.getUuid(), buildRsaCreateKeyRequest("own-sign"));
+        UUID privateKeyUuid = UUID.fromString(pair.getPrivateKeyData().getUuid());
+
+        SignDataRequestDto request = new SignDataRequestDto();
+        request.setSignatureAttributes(buildRsaSignatureAttributes());
+        request.setData(List.of(new SignatureRequestData(PLAINTEXT, "item-1")));
+
+        UUID wrongTokenUuid = otherTokenInstance.getUuid();
+        assertThrows(NotFoundException.class,
+                () -> cryptographicOperationsService.signData(wrongTokenUuid, privateKeyUuid, request),
+                "signData should reject a key that belongs to a different token instance");
+    }
+
+    @Test
+    void verifyData_withMismatchedTokenUuid_shouldThrowNotFoundException() throws NotFoundException {
+        KeyPairDataResponseDto pair = keyManagementService.createKeyPair(
+                tokenInstance.getUuid(), buildRsaCreateKeyRequest("own-verify"));
+        UUID publicKeyUuid = UUID.fromString(pair.getPublicKeyData().getUuid());
+
+        VerifyDataRequestDto request = new VerifyDataRequestDto();
+        request.setSignatureAttributes(buildRsaSignatureAttributes());
+        request.setData(List.of(new SignatureRequestData(PLAINTEXT, "item-1")));
+        request.setSignatures(List.of(new SignatureRequestData(new byte[256], "item-1")));
+
+        UUID wrongTokenUuid = otherTokenInstance.getUuid();
+        assertThrows(NotFoundException.class,
+                () -> cryptographicOperationsService.verifyData(wrongTokenUuid, publicKeyUuid, request),
+                "verifyData should reject a key that belongs to a different token instance");
+    }
+
+    @Test
+    void encryptData_withMismatchedTokenUuid_shouldThrowNotFoundException() throws NotFoundException {
+        KeyPairDataResponseDto pair = keyManagementService.createKeyPair(
+                tokenInstance.getUuid(), buildRsaCreateKeyRequest("own-encrypt"));
+        UUID publicKeyUuid = UUID.fromString(pair.getPublicKeyData().getUuid());
+
+        CipherDataRequestDto request = new CipherDataRequestDto();
+        request.setCipherAttributes(buildRsaPkcs1CipherAttributes());
+        request.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
+
+        UUID wrongTokenUuid = otherTokenInstance.getUuid();
+        assertThrows(NotFoundException.class,
+                () -> cryptographicOperationsService.encryptData(wrongTokenUuid, publicKeyUuid, request),
+                "encryptData should reject a key that belongs to a different token instance");
+    }
+
+    @Test
+    void decryptData_withMismatchedTokenUuid_shouldThrowNotFoundException() throws NotFoundException {
+        KeyPairDataResponseDto pair = keyManagementService.createKeyPair(
+                tokenInstance.getUuid(), buildRsaCreateKeyRequest("own-decrypt"));
+        UUID privateKeyUuid = UUID.fromString(pair.getPrivateKeyData().getUuid());
+
+        CipherDataRequestDto request = new CipherDataRequestDto();
+        request.setCipherAttributes(buildRsaPkcs1CipherAttributes());
+        request.setCipherData(List.of(new CipherRequestData(PLAINTEXT, "item-1")));
+
+        UUID wrongTokenUuid = otherTokenInstance.getUuid();
+        assertThrows(NotFoundException.class,
+                () -> cryptographicOperationsService.decryptData(wrongTokenUuid, privateKeyUuid, request),
+                "decryptData should reject a key that belongs to a different token instance");
+    }
+
+    private CreateKeyRequestDto buildRsaCreateKeyRequest(String alias) {
+        List<RequestAttribute> attrs = new ArrayList<>();
+        attrs.add(buildAliasAttribute(alias));
+        attrs.add(buildAlgorithmAttribute(KeyAlgorithm.RSA));
+
+        RequestAttributeV2 sizeAttr = new RequestAttributeV2();
+        sizeAttr.setName(RsaKeyAttributes.ATTRIBUTE_DATA_RSA_KEY_SIZE);
+        sizeAttr.setContentType(AttributeContentType.INTEGER);
+        sizeAttr.setContent(List.of(new IntegerAttributeContentV2("RSA_2048", 2048)));
+        attrs.add(sizeAttr);
+
+        CreateKeyRequestDto req = new CreateKeyRequestDto();
+        req.setCreateKeyAttributes(attrs);
+        return req;
+    }
+
+    private List<RequestAttribute> buildRsaSignatureAttributes() {
+        List<RequestAttribute> attrs = new ArrayList<>();
+
+        RequestAttributeV2 schemeAttr = new RequestAttributeV2();
+        schemeAttr.setName(RsaKeyAttributes.ATTRIBUTE_DATA_RSA_SIG_SCHEME);
+        schemeAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 schemeContent = new StringAttributeContentV2();
+        schemeContent.setReference(RsaSignatureScheme.PKCS1_v1_5.getCode());
+        schemeContent.setData(RsaSignatureScheme.PKCS1_v1_5.getCode());
+        schemeAttr.setContent(List.of(schemeContent));
+        attrs.add(schemeAttr);
+
+        RequestAttributeV2 digestAttr = new RequestAttributeV2();
+        digestAttr.setName(RsaKeyAttributes.ATTRIBUTE_DATA_SIG_DIGEST);
+        digestAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 digestContent = new StringAttributeContentV2();
+        digestContent.setReference(DigestAlgorithm.SHA_256.getCode());
+        digestContent.setData(DigestAlgorithm.SHA_256.getCode());
+        digestAttr.setContent(List.of(digestContent));
+        attrs.add(digestAttr);
+
+        return attrs;
+    }
+
+    private List<RequestAttribute> buildRsaPkcs1CipherAttributes() {
+        List<RequestAttribute> attrs = new ArrayList<>();
+
+        RequestAttributeV2 schemeAttr = new RequestAttributeV2();
+        schemeAttr.setName(RsaCipherAttributes.ATTRIBUTE_DATA_RSA_ENC_SCHEME_NAME);
+        schemeAttr.setContentType(AttributeContentType.STRING);
+        StringAttributeContentV2 schemeContent = new StringAttributeContentV2();
+        schemeContent.setReference(RsaEncryptionScheme.PKCS1_v1_5.getCode());
+        schemeContent.setData(RsaEncryptionScheme.PKCS1_v1_5.getCode());
+        schemeAttr.setContent(List.of(schemeContent));
+        attrs.add(schemeAttr);
+
+        return attrs;
+    }
+}

--- a/src/test/java/com/czertainly/cp/soft/util/KeyStoreUtilTest.java
+++ b/src/test/java/com/czertainly/cp/soft/util/KeyStoreUtilTest.java
@@ -4,6 +4,9 @@ import com.czertainly.api.model.connector.cryptography.key.value.SpkiKeyValue;
 import com.czertainly.cp.soft.collection.EcdsaCurveName;
 import com.czertainly.cp.soft.collection.FalconDegree;
 import com.czertainly.cp.soft.collection.MLKEMSecurityCategory;
+import com.czertainly.cp.soft.exception.CryptographicOperationException;
+import com.czertainly.cp.soft.model.CachedKeyData;
+import com.czertainly.cp.soft.model.CachedKeyMaterial;
 import org.bouncycastle.jcajce.provider.asymmetric.mlkem.BCMLKEMPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.pqc.jcajce.provider.BouncyCastlePQCProvider;
@@ -15,6 +18,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 import java.security.KeyStore;
 import java.security.Security;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -160,5 +166,29 @@ class KeyStoreUtilTest {
         KeyStore ks = KeyStoreUtil.loadKeystore(bytes, PASSWORD);
 
         assertDoesNotThrow(() -> KeyStoreUtil.deleteAliasFromKeyStore(ks, "non-existent"));
+    }
+
+    // -------------------------------------------------------------------------
+    // getPrivateKey / getPublicKey — error paths
+    // -------------------------------------------------------------------------
+
+    @Test
+    void getPrivateKey_missingAlias_throwsCryptographicOperationException() {
+        CachedKeyData key = new CachedKeyData(UUID.randomUUID(), UUID.randomUUID(), "ghost-alias",
+                null, null, null, null, null, 0, List.of());
+        CachedKeyMaterial material = new CachedKeyMaterial(Map.of(), Map.of());
+
+        assertThrows(CryptographicOperationException.class,
+                () -> KeyStoreUtil.getPrivateKey(key, material));
+    }
+
+    @Test
+    void getPublicKey_missingAlias_throwsCryptographicOperationException() {
+        CachedKeyData key = new CachedKeyData(UUID.randomUUID(), UUID.randomUUID(), "ghost-alias",
+                null, null, null, null, null, 0, List.of());
+        CachedKeyMaterial material = new CachedKeyMaterial(Map.of(), Map.of());
+
+        assertThrows(CryptographicOperationException.class,
+                () -> KeyStoreUtil.getPublicKey(key, material));
     }
 }

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatIT.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatIT.java
@@ -343,8 +343,7 @@ class V202604211200__MigrateMLKEMKeyStorageFormatIT {
 
     private static void insertMlkemPublicKeyData(Connection conn, UUID keyDataUuid, UUID tokenInstanceUuid,
                                                  String alias, PublicKey publicKey) throws Exception {
-        // Match the JSON structure produced by RawKeyValue / SpkiKeyValue serialization:
-        // {"value": "<base64-encoded SPKI bytes>"}
+        // Match the JSON structure produced by RawKeyValue / SpkiKeyValue serialization.
         String base64Spki = Base64.getEncoder().encodeToString(publicKey.getEncoded());
         Map<String, String> valueMap = new HashMap<>();
         valueMap.put("value", base64Spki);

--- a/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatIT.java
+++ b/src/test/java/db/migration/V202604211200__MigrateMLKEMKeyStorageFormatIT.java
@@ -1,0 +1,406 @@
+package db.migration;
+
+import com.czertainly.api.model.common.enums.cryptography.KeyAlgorithm;
+import com.czertainly.api.model.common.enums.cryptography.KeyFormat;
+import com.czertainly.api.model.common.enums.cryptography.KeyType;
+import com.czertainly.cp.soft.Application;
+import com.czertainly.cp.soft.util.KeyStoreUtil;
+import com.czertainly.cp.soft.util.SecretEncodingVersion;
+import com.czertainly.cp.soft.util.SecretsUtil;
+import com.czertainly.cp.soft.util.X509Util;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DERBMPString;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateHolder;
+import org.bouncycastle.jcajce.spec.MLKEMParameterSpec;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OutputEncryptor;
+import org.bouncycastle.pkcs.PKCS12PfxPdu;
+import org.bouncycastle.pkcs.PKCS12PfxPduBuilder;
+import org.bouncycastle.pkcs.PKCS12SafeBagBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCS12MacCalculatorBuilder;
+import org.bouncycastle.pkcs.jcajce.JcePKCSPBEOutputEncryptorBuilder;
+import org.flywaydb.core.api.configuration.Configuration;
+import org.flywaydb.core.api.migration.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.sql.DataSource;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Spring Boot integration test for {@link V202604211200__MigrateMLKEMKeyStorageFormat}.
+ *
+ * <p>The test seeds the in-memory HSQL database with a {@code token_instance} row that contains a
+ * legacy ML-KEM keystore (private key stored as raw PKCS8 bytes, no certificate chain) and a
+ * corresponding {@code key_data} row that holds the public key in SPKI format — exactly the state
+ * that would be present after upgrading from 1.3.1 to 1.4.0 without running any migration.
+ *
+ * <p>After running the migration, it asserts that:
+ * <ul>
+ *   <li>The keystore blob in {@code token_instance.data} now contains an orphan certificate for every ML-KEM alias.</li>
+ *   <li>The private key is still recoverable and its bytes are unchanged.</li>
+ *   <li>Non-ML-KEM entries in the same keystore are untouched.</li>
+ *   <li>Token instances that already use the new format are not re-written.</li>
+ * </ul>
+ */
+@SpringBootTest(classes = Application.class)
+class V202604211200__MigrateMLKEMKeyStorageFormatIT {
+
+    private static final String PASSWORD = "integration-test-password";
+    private static final String MLKEM_ALIAS = "my-mlkem-key";
+    private static final String ECDSA_ALIAS = "my-ecdsa-key";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Autowired
+    private DataSource dataSource;
+
+    /**
+     * UUIDs of rows created during a test — cleaned up in @AfterEach.
+     */
+    private final Map<UUID, UUID> createdTokens = new HashMap<>();  // tokenUuid → tokenUuid
+
+    @BeforeAll
+    static void ensureBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @AfterEach
+    void cleanUp() throws Exception {
+        if (createdTokens.isEmpty()) return;
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            for (UUID tokenUuid : createdTokens.keySet()) {
+                try (PreparedStatement ps = conn.prepareStatement("DELETE FROM key_data WHERE token_instance_uuid = ?")) {
+                    ps.setObject(1, tokenUuid);
+                    ps.executeUpdate();
+                }
+                try (PreparedStatement ps = conn.prepareStatement("DELETE FROM token_instance WHERE uuid = ?")) {
+                    ps.setObject(1, tokenUuid);
+                    ps.executeUpdate();
+                }
+            }
+        }
+        createdTokens.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests
+    // -------------------------------------------------------------------------
+
+    @Test
+    void migrationConvertsLegacyMlkemEntry() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            // Seed the database with a legacy token instance.
+            UUID tokenUuid = UUID.randomUUID();
+            byte[] legacyKeystore = buildLegacyKeystore(mlkemPair, PASSWORD);
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, legacyKeystore);
+
+            // Seed the key_data row (public key in SPKI format, as written by KeyManagementServiceImpl).
+            UUID keyDataUuid = UUID.randomUUID();
+            insertMlkemPublicKeyData(conn, keyDataUuid, tokenUuid, MLKEM_ALIAS, mlkemPair.getPublic());
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            // Run the migration.
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            // Load the updated keystore from the database.
+            KeyStore migratedKs = loadUpdatedKeystore(conn, tokenUuid, PASSWORD);
+
+            // The ML-KEM alias must now have a certificate.
+            Certificate cert = migratedKs.getCertificate(MLKEM_ALIAS);
+            assertNotNull(cert, "ML-KEM alias must have an orphan certificate after migration");
+
+            // The certificate's public key must match the original.
+            assertArrayEquals(mlkemPair.getPublic().getEncoded(), cert.getPublicKey().getEncoded(),
+                    "Certificate public key must match the original ML-KEM public key");
+
+            // The private key must still be recoverable.
+            Key recoveredKey = migratedKs.getKey(MLKEM_ALIAS, PASSWORD.toCharArray());
+            assertNotNull(recoveredKey, "Private key must still be recoverable after migration");
+            assertArrayEquals(mlkemPair.getPrivate().getEncoded(), recoveredKey.getEncoded(),
+                    "Private key bytes must be unchanged after migration");
+        }
+    }
+
+    @Test
+    void migrationLeavesNewFormatUnchanged() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            byte[] newFormatKeystore = buildNewFormatKeystore(mlkemPair, PASSWORD);
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, newFormatKeystore);
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            // Record the data blob before the migration.
+            String dataBefore = queryKeystoreData(conn, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            // The data blob must not have changed (migration must not re-write already-new keystores).
+            String dataAfter = queryKeystoreData(conn, tokenUuid);
+            assertEquals(dataBefore, dataAfter,
+                    "A keystore already in the new format must not be rewritten by the migration");
+        }
+    }
+
+    @Test
+    void migrationPreservesNonMlkemEntriesAlongsideMigratedMlkemEntry() throws Exception {
+        KeyPair mlkemPair = generateMlkemKeyPair();
+
+        // Build a PKCS12 that holds BOTH a legacy ML-KEM entry AND a normal ECDSA entry using the
+        // low-level builder (BC 1.73+ no longer supports setKeyEntry(alias, byte[], null)).
+        KeyPairGenerator ecKpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        ecKpg.initialize(new java.security.spec.ECGenParameterSpec("P-256"));
+        KeyPair ecPair = ecKpg.generateKeyPair();
+        X509Certificate ecCert = X509Util.generateEcdsaOrphanX509Certificate(ecPair);
+
+        byte[] keystoreBytes = buildMixedPkcs12(MLKEM_ALIAS, mlkemPair.getPrivate(), ECDSA_ALIAS,
+                ecPair.getPrivate(), ecCert, PASSWORD.toCharArray());
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            UUID tokenUuid = UUID.randomUUID();
+            String encryptedPassword = SecretsUtil.encryptAndEncodeSecretString(PASSWORD, SecretEncodingVersion.V1);
+            insertTokenInstance(conn, tokenUuid, encryptedPassword, keystoreBytes);
+            insertMlkemPublicKeyData(conn, UUID.randomUUID(), tokenUuid, MLKEM_ALIAS, mlkemPair.getPublic());
+            createdTokens.put(tokenUuid, tokenUuid);
+
+            V202604211200__MigrateMLKEMKeyStorageFormat migration = new V202604211200__MigrateMLKEMKeyStorageFormat();
+            migration.migrate(new JdbcMigrationContext(conn));
+
+            KeyStore migratedKs = loadUpdatedKeystore(conn, tokenUuid, PASSWORD);
+
+            // ML-KEM must now have a cert.
+            assertNotNull(migratedKs.getCertificate(MLKEM_ALIAS), "ML-KEM alias must have a cert after migration");
+
+            // ECDSA entry must still be present and functional.
+            assertNotNull(migratedKs.getCertificate(ECDSA_ALIAS), "ECDSA alias must still have its cert");
+            Key ecKey = migratedKs.getKey(ECDSA_ALIAS, PASSWORD.toCharArray());
+            assertNotNull(ecKey, "ECDSA private key must still be recoverable");
+            assertArrayEquals(ecPair.getPrivate().getEncoded(), ecKey.getEncoded(),
+                    "ECDSA private key bytes must be unchanged");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — keystore construction
+    // -------------------------------------------------------------------------
+
+    private static KeyPair generateMlkemKeyPair() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("ML-KEM", BouncyCastleProvider.PROVIDER_NAME);
+        kpg.initialize(MLKEMParameterSpec.fromName("ML-KEM-768"));
+        return kpg.generateKeyPair();
+    }
+
+    /**
+     * Builds a PKCS12 keystore in the <em>old</em> (1.3.1) format: bare PKCS8ShroudedKeyBag, no cert.
+     *
+     * <p>BouncyCastle 1.73+ no longer supports {@code setKeyEntry(alias, byte[], null)} on PKCS12;
+     * this method uses the low-level {@link PKCS12PfxPduBuilder} instead.
+     */
+    private static byte[] buildLegacyKeystore(KeyPair mlkemPair, String password) throws Exception {
+        return buildBareKeyPkcs12(MLKEM_ALIAS, mlkemPair.getPrivate(), password.toCharArray());
+    }
+
+    /**
+     * Builds a PKCS12 keystore in the <em>new</em> (1.4.0) format: PrivateKeyEntry + orphan cert.
+     */
+    private static byte[] buildNewFormatKeystore(KeyPair mlkemPair, String password) throws Exception {
+        KeyStore ks = KeyStore.getInstance("PKCS12", BouncyCastleProvider.PROVIDER_NAME);
+        ks.load(null, password.toCharArray());
+        X509Certificate cert = X509Util.generateMLKEMOrphanX509Certificate(mlkemPair);
+        ks.setKeyEntry(MLKEM_ALIAS, mlkemPair.getPrivate(), password.toCharArray(), new Certificate[]{cert});
+        return KeyStoreUtil.saveKeystore(ks, password);
+    }
+
+    /**
+     * Builds a PKCS12 containing a single encrypted key bag for the given private key with no
+     * associated certificate bag — i.e. the legacy 1.3.1 storage format.
+     */
+    private static byte[] buildBareKeyPkcs12(String alias, PrivateKey privateKey, char[] password)
+            throws Exception {
+        PrivateKeyInfo pkInfo = PrivateKeyInfo.getInstance(privateKey.getEncoded());
+        OutputEncryptor keyEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd3_KeyTripleDES_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+
+        byte[] localKeyId = new byte[20];
+        new SecureRandom().nextBytes(localKeyId);
+
+        PKCS12SafeBagBuilder keyBagBuilder = new PKCS12SafeBagBuilder(pkInfo, keyEncryptor);
+        keyBagBuilder.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(alias));
+        keyBagBuilder.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(localKeyId));
+
+        PKCS12PfxPduBuilder pfxBuilder = new PKCS12PfxPduBuilder();
+        pfxBuilder.addData(keyBagBuilder.build());
+
+        PKCS12PfxPdu pfx = pfxBuilder.build(
+                new JcePKCS12MacCalculatorBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME),
+                password);
+
+        return pfx.getEncoded("DER");
+    }
+
+    /**
+     * Builds a PKCS12 containing:
+     * <ul>
+     *   <li>A bare (cert-less) key bag for {@code legacyAlias/legacyKey} — legacy format.</li>
+     *   <li>A key bag and certificate bag linked by {@code LocalKeyId} for
+     *       {@code newAlias/newKey/newCert} — new format.</li>
+     * </ul>
+     */
+    private static byte[] buildMixedPkcs12(String legacyAlias, PrivateKey legacyKey, String newAlias,
+                                           PrivateKey newKey, X509Certificate newCert, char[] password)
+            throws Exception {
+        OutputEncryptor keyEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd3_KeyTripleDES_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+        OutputEncryptor certEncryptor = new JcePKCSPBEOutputEncryptorBuilder(
+                PKCSObjectIdentifiers.pbeWithSHAAnd128BitRC2_CBC)
+                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
+                .build(password);
+
+        // Legacy key bag (no cert)
+        byte[] legacyLocalKeyId = new byte[20];
+        new SecureRandom().nextBytes(legacyLocalKeyId);
+        PrivateKeyInfo legacyPkInfo = PrivateKeyInfo.getInstance(legacyKey.getEncoded());
+        PKCS12SafeBagBuilder legacyKeyBag = new PKCS12SafeBagBuilder(legacyPkInfo, keyEncryptor);
+        legacyKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(legacyAlias));
+        legacyKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(legacyLocalKeyId));
+
+        // New-format key + cert linked by a shared localKeyId
+        byte[] newLocalKeyId = new byte[20];
+        new SecureRandom().nextBytes(newLocalKeyId);
+        PrivateKeyInfo newPkInfo = PrivateKeyInfo.getInstance(newKey.getEncoded());
+        PKCS12SafeBagBuilder newKeyBag = new PKCS12SafeBagBuilder(newPkInfo, keyEncryptor);
+        newKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(newAlias));
+        newKeyBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(newLocalKeyId));
+
+        PKCS12SafeBagBuilder newCertBag = new PKCS12SafeBagBuilder(new JcaX509CertificateHolder(newCert));
+        newCertBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_friendlyName, new DERBMPString(newAlias));
+        newCertBag.addBagAttribute(PKCSObjectIdentifiers.pkcs_9_at_localKeyId, new DEROctetString(newLocalKeyId));
+
+        PKCS12PfxPduBuilder pfxBuilder = new PKCS12PfxPduBuilder();
+        pfxBuilder.addData(legacyKeyBag.build());
+        pfxBuilder.addData(newKeyBag.build());
+        pfxBuilder.addEncryptedData(certEncryptor, newCertBag.build());
+
+        PKCS12PfxPdu pfx = pfxBuilder.build(new JcePKCS12MacCalculatorBuilder().setProvider(BouncyCastleProvider.PROVIDER_NAME), password);
+
+        return pfx.getEncoded("DER");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers — JDBC data setup / query
+    // -------------------------------------------------------------------------
+
+    private static void insertTokenInstance(Connection conn, UUID tokenUuid,
+                                            String encryptedCode, byte[] keystoreBytes)
+            throws Exception {
+        String data = Base64.getEncoder().encodeToString(keystoreBytes);
+        String sql = "INSERT INTO token_instance (uuid, name, code, data, timestamp) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setObject(1, tokenUuid);
+            ps.setString(2, "migration-test-token-" + tokenUuid);
+            ps.setString(3, encryptedCode);
+            ps.setString(4, data);
+            ps.executeUpdate();
+        }
+    }
+
+    private static void insertMlkemPublicKeyData(Connection conn, UUID keyDataUuid, UUID tokenInstanceUuid,
+                                                 String alias, PublicKey publicKey) throws Exception {
+        // Match the JSON structure produced by RawKeyValue / SpkiKeyValue serialization:
+        // {"value": "<base64-encoded SPKI bytes>"}
+        String base64Spki = Base64.getEncoder().encodeToString(publicKey.getEncoded());
+        Map<String, String> valueMap = new HashMap<>();
+        valueMap.put("value", base64Spki);
+        String valueJson = MAPPER.writeValueAsString(valueMap);
+
+        String sql = "INSERT INTO key_data "
+                + "(uuid, name, algorithm, type, format, value, length, token_instance_uuid) "
+                + "VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setObject(1, keyDataUuid);
+            ps.setString(2, alias);
+            ps.setString(3, KeyAlgorithm.MLKEM.name());
+            ps.setString(4, KeyType.PUBLIC_KEY.name());
+            ps.setString(5, KeyFormat.SPKI.name());
+            ps.setString(6, valueJson);
+            ps.setInt(7, 768); // NIST security category level used as a proxy for key length
+            ps.setObject(8, tokenInstanceUuid);
+            ps.executeUpdate();
+        }
+    }
+
+    private static String queryKeystoreData(Connection conn, UUID tokenUuid) throws Exception {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT data FROM token_instance WHERE uuid = ?")) {
+            ps.setObject(1, tokenUuid);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertTrue(rs.next(), "token_instance row must exist");
+                return rs.getString("data");
+            }
+        }
+    }
+
+    private static KeyStore loadUpdatedKeystore(Connection conn, UUID tokenUuid, String password) throws Exception {
+        String data = queryKeystoreData(conn, tokenUuid);
+        byte[] keystoreBytes = Base64.getDecoder().decode(data);
+        return KeyStoreUtil.loadKeystore(keystoreBytes, password);
+    }
+
+    // -------------------------------------------------------------------------
+    // Minimal Flyway Context adapter
+    // -------------------------------------------------------------------------
+
+    /**
+     * Minimal implementation of {@link Context} that wraps an existing JDBC {@link Connection}.
+     * Flyway's {@link org.flywaydb.core.api.migration.BaseJavaMigration#migrate} only uses
+     * {@link Context#getConnection()}, so a stub for {@link Context#getConfiguration()} suffices.
+     */
+    private record JdbcMigrationContext(Connection connection) implements Context {
+        @Override
+        public Configuration getConfiguration() {
+            return null; // not used by this migration
+        }
+
+        @Override
+        public Connection getConnection() {
+            return connection;
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,3 +28,12 @@ secrets:
 
 token:
   deleteOnRemove: ${TOKEN_DELETE_ON_REMOVE:false}
+
+provider:
+  cache:
+    keystore:
+      ttl-seconds: 60
+      max-size: 500
+    keydata:
+      ttl-seconds: 300
+      max-size: 10000


### PR DESCRIPTION
With the fixes:
```
┌────────────────────────────────────────┐
│     SIGN OPERATION SUMMARY             │
├────────────────────────────────────────┤
│  Total requests : 530901               │
│  Duration       : 70.3 s               │
│  Throughput     : 7552.36 req/s        │
│  p(95) latency  : 1.83 ms              │
│  p(99) latency  : 2.31 ms              │
└────────────────────────────────────────┘
```


Previously:
```
┌────────────────────────────────────────┐
│           SIGN OPERATION SUMMARY       │
├────────────────────────────────────────┤
│  Total requests : 30778                │
│  Duration       : 70.5 s               │
│  Throughput     : 436.69 req/s         │
│  p(95) latency  : 29.79 ms             │
│  p(99) latency  : 38.07 ms             │
└────────────────────────────────────────┘
```